### PR TITLE
Handle Starlette and handle any Oauth2 token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Switch from Flask to Starlette.
 
 ## [3.2.0] - 2019-12-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Switch from Flask to Starlette.
+- Flask specifics are now within layabauth.flask.
+- flask.g.current_user does not exists, instead, the validated token and the decoded token body are available in flask.g.token and flask.g.token_body
+- `upn` field is not expected in token anymore. It is now up to the user to select what information they want to extract from the decoded token body.
+- `UserIdFilter` class now requires `token_field_name` parameter to know what token body field value must be set inside `user_id`.
+- `auth_mock` fixture now expects `token_body` fixture providing the decoded token body instead of `upn` fixture.
 
 ## [3.2.0] - 2019-12-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [4.0.0] - 2020-04-20
 ### Changed
 - Flask specifics are now within layabauth.flask.
 - flask.g.current_user does not exists, instead, the validated token and the decoded token body are available in flask.g.token and flask.g.token_body
@@ -16,5 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/layabauth/compare/v3.2.0...HEAD
+[Unreleased]: https://github.com/Colin-b/layabauth/compare/v4.0.0...HEAD
+[4.0.0]: https://github.com/Colin-b/layabauth/compare/v3.2.0...v4.0.0
 [3.2.0]: https://github.com/Colin-b/layabauth/releases/tag/v3.2.0

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ from starlette.responses import PlainTextResponse
 import layabauth.starlette
 
 backend = layabauth.starlette.OAuth2IdTokenBackend(
-    identity_provider_url="https://test_identity_provider",
+    identity_provider_url="https://sts.windows.net/common/discovery/keys",
     create_user=lambda token, token_body: SimpleUser(token_body["name"]),
     scopes=lambda token, token_body: ["my_scope"]
 )

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 <p align="center">
 <a href="https://pypi.org/project/layabauth/"><img alt="pypi version" src="https://img.shields.io/pypi/v/layabauth"></a>
-<a href="https://travis-ci.org/Colin-b/layabauth"><img alt="Build status" src="https://api.travis-ci.org/Colin-b/layabauth.svg?branch=develop"></a>
-<a href="https://travis-ci.org/Colin-b/layabauth"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
+<a href="https://travis-ci.com/Colin-b/layabauth"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/layabauth.svg?branch=master"></a>
+<a href="https://travis-ci.com/Colin-b/layabauth"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.org/Colin-b/layabauth"><img alt="Number of tests" src="https://img.shields.io/badge/tests-20 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/layabauth"><img alt="Number of tests" src="https://img.shields.io/badge/tests-20 passed-blue"></a>
 <a href="https://pypi.org/project/layabauth/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/layabauth"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h2 align="center">Authentication for layab</h2>
+<h2 align="center">Handle OAuth2 authentication for REST APIs</h2>
 
 <p align="center">
 <a href="https://pypi.org/project/layabauth/"><img alt="pypi version" src="https://img.shields.io/pypi/v/layabauth"></a>
@@ -9,13 +9,52 @@
 <a href="https://pypi.org/project/layabauth/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/layabauth"></a>
 </p>
 
-Provides a decorator to ensure that, in a context of a `Flask` server, a valid OAuth2 token was received.
-
 As expected by the HTTP specification, token is extracted from `Authorization` header and must be prefixed with `Bearer `.
 
+Token will then be validated and in case it is valid, you will be able to access the raw token (as string) and the decoded token body (as dictionary).
+
+## Starlette
+
+Provides a [Starlette authentication backend](https://www.starlette.io/authentication/): `layabauth.starlette.OAuth2IdTokenBackend`.
+
+3 arguments are required:
+* The identity provided URL to validate the token key.
+* A callable to create the [authenticated user](https://www.starlette.io/authentication/#users) based on received token.
+* A callable to returns [authenticated user scopes](https://www.starlette.io/authentication/#permissions) based on received token.
+
+Below is a sample `Starlette` application with an endpoint requesting a Microsoft issued OAuth2 token.
+
+```python
+import starlette.applications
+from starlette.authentication import SimpleUser, requires
+from starlette.middleware import Middleware
+from starlette.middleware.authentication import AuthenticationMiddleware
+from starlette.responses import PlainTextResponse
+
+import layabauth.starlette
+
+backend = layabauth.starlette.OAuth2IdTokenBackend(
+    identity_provider_url="https://test_identity_provider",
+    create_user=lambda token, token_body: SimpleUser(token_body["name"]),
+    scopes=lambda token, token_body: ["my_scope"]
+)
+app = starlette.applications.Starlette(middleware=[Middleware(AuthenticationMiddleware, backend=backend)])
+
+@app.route("/my_endpoint")
+@requires('my_scope')
+async def my_endpoint(request):
+    return PlainTextResponse(request.user.display_name)
+```
+
+## Flask
+
+Provides a decorator `layabauth.flask.requires_authentication` to ensure that, in a context of a `Flask` application, a valid OAuth2 token was received.
+
+1 argument is required:
+* The identity provided URL to validate the token key.
+
 If validation fails, an `werkzeug.exceptions.Unauthorized` exception is raised.
-Otherwise user details are stored in `flask.g.current_user`, this variable is an instance of the `User` class, 
-it contains `name` property holding the authenticated user name (extracted from the upn field inside the token).
+Otherwise token is stored in `flask.g.token` and decoded token body is stored in `flask.g.token_body`.
 
 Decorator works fine on `flask-restplus` methods as well.
 
@@ -23,40 +62,42 @@ Below is a sample `Flask` application with an endpoint requesting a Microsoft is
 
 ```python
 import flask
-import layabauth
+import layabauth.flask
 
 app = flask.Flask(__name__)
 
 @app.route("/my_endpoint")
-@layabauth.requires_authentication("https://sts.windows.net/common/discovery/keys")
+@layabauth.flask.requires_authentication("https://sts.windows.net/common/discovery/keys")
 def my_endpoint():
-    return "OK"
+    # Return the content of the name entry within the decoded token body.
+    return flask.Response(flask.g.token_body["name"])
 
 app.run()
 ```
 
 ## OpenAPI
 
-You can generate OpenAPI `security` definition thanks to `layabauth.authorizations`.
+You can generate OpenAPI 2.0 `security` definition thanks to `layabauth.authorizations`.
 
-You can generate OpenAPI `method security` thanks to `layabauth.method_authorizations`
+You can generate OpenAPI 2.0 `method security` thanks to `layabauth.method_authorizations`
 
 ## Testing
 
 Authentication can be mocked using `layabauth.testing.auth_mock` `pytest` fixture.
 
-`upn` `pytest` fixture returning the UPN located in token used in tests must be provided.
+`token_body` `pytest` fixture returning the decoded token body used in tests must be provided.
 
 ```python
 from layabauth.testing import *
 
 @pytest.fixture
-def upn():
-    return "TEST@email.com"
+def token_body():
+    return {"name": "TEST@email.com"}
 
 
-def test_authentication(auth_mock):
-    pass
+def test_authentication(auth_mock, client):
+    response = client.get("/my_endpoint", headers={"Authentication": "Bearer mocked_token"})
+    assert response.text == "TEST@email.com"
 ```
 
 ## How to install

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/layabauth/__init__.py
+++ b/layabauth/__init__.py
@@ -1,2 +1,2 @@
 from layabauth.version import __version__
-from layabauth._authentication import requires_authentication, UserIdFilter, authorizations, method_authorizations
+from layabauth._openapi import authorizations, method_authorizations

--- a/layabauth/_authentication.py
+++ b/layabauth/_authentication.py
@@ -1,10 +1,5 @@
-import logging
-import functools
-from typing import Optional
+from typing import Mapping
 
-import flask
-import werkzeug.exceptions
-import jwt.exceptions
 import oauth2helper
 
 
@@ -42,48 +37,11 @@ def method_authorizations(*scopes) -> dict:
 
 
 def _to_user(token: str, identity_provider_url: str) -> User:
-    try:
-        json_header, json_body = oauth2helper.validate(token, identity_provider_url)
-        return User(json_body)
-    except (
-        jwt.exceptions.InvalidTokenError or jwt.exceptions.InvalidKeyError
-    ) as e:
-        raise werkzeug.exceptions.Unauthorized(description=str(e))
+    json_header, json_body = oauth2helper.validate(token, identity_provider_url)
+    return User(json_body)
 
 
-def _get_token():
-    authorization = flask.request.headers.get("Authorization")
+def _get_token(headers: Mapping[str, str]):
+    authorization = headers.get("Authorization")
     if authorization and authorization.startswith("Bearer "):
         return authorization[7:]
-
-
-def requires_authentication(identity_provider_url: str):
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*func_args, **func_kwargs):
-            flask.g.current_user = _to_user(_get_token(), identity_provider_url)
-            return func(*func_args, **func_kwargs)
-
-        return wrapper
-    return decorator
-
-
-def _extract_user_name() -> Optional[str]:
-    if getattr(flask.g, "current_user", None):
-        return flask.g.current_user.name
-    try:
-        json_header, json_body = oauth2helper.decode(_get_token())
-        return User(json_body).name
-    except:
-        return ""
-
-
-class UserIdFilter(logging.Filter):
-    """
-    This is a logging filter that makes the user identifier available for use in the logging format.
-    Note that we are checking if we are in a request context, as we may want to log things before Flask is fully loaded.
-    """
-
-    def filter(self, record):
-        record.user_id = _extract_user_name() if flask.has_request_context() else ""
-        return True

--- a/layabauth/_http.py
+++ b/layabauth/_http.py
@@ -1,0 +1,7 @@
+from typing import Mapping
+
+
+def _get_token(headers: Mapping[str, str]):
+    authorization = headers.get("Authorization")
+    if authorization and authorization.startswith("Bearer "):
+        return authorization[7:]

--- a/layabauth/_openapi.py
+++ b/layabauth/_openapi.py
@@ -1,13 +1,3 @@
-from typing import Mapping
-
-import oauth2helper
-
-
-class User:
-    def __init__(self, decoded_body: dict):
-        self.name = oauth2helper.user_name(decoded_body)
-
-
 def authorizations(auth_url, **scopes) -> dict:
     """
     Return all security definitions.
@@ -34,14 +24,3 @@ def method_authorizations(*scopes) -> dict:
     :param scopes: All scope names that should be available (as string).
     """
     return {"security": [{"oauth2": scopes}]}
-
-
-def _to_user(token: str, identity_provider_url: str) -> User:
-    json_header, json_body = oauth2helper.validate(token, identity_provider_url)
-    return User(json_body)
-
-
-def _get_token(headers: Mapping[str, str]):
-    authorization = headers.get("Authorization")
-    if authorization and authorization.startswith("Bearer "):
-        return authorization[7:]

--- a/layabauth/flask.py
+++ b/layabauth/flask.py
@@ -1,0 +1,50 @@
+import logging
+import functools
+from typing import Optional
+
+import flask
+import werkzeug
+import jwt.exceptions
+import oauth2helper
+
+from layabauth._authentication import _to_user, _get_token, User
+
+
+def requires_authentication(identity_provider_url: str):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*func_args, **func_kwargs):
+            try:
+                flask.g.current_user = _to_user(
+                    _get_token(flask.request.headers), identity_provider_url
+                )
+            except (
+                jwt.exceptions.InvalidTokenError or jwt.exceptions.InvalidKeyError
+            ) as e:
+                raise werkzeug.exceptions.Unauthorized(description=str(e))
+            return func(*func_args, **func_kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def _extract_user_name() -> Optional[str]:
+    if getattr(flask.g, "current_user", None):
+        return flask.g.current_user.name
+    try:
+        json_header, json_body = oauth2helper.decode(_get_token(flask.request.headers))
+        return User(json_body).name
+    except:
+        return ""
+
+
+class UserIdFilter(logging.Filter):
+    """
+    This is a logging filter that makes the user identifier available for use in the logging format.
+    Note that we are checking if we are in a request context, as we may want to log things before Flask is fully loaded.
+    """
+
+    def filter(self, record):
+        record.user_id = _extract_user_name() if flask.has_request_context() else ""
+        return True

--- a/layabauth/starlette.py
+++ b/layabauth/starlette.py
@@ -17,6 +17,11 @@ class OAuth2IdTokenBackend(AuthenticationBackend):
     """Handle authentication via OAuth2 id-token (implicit flow, authorization code, with or without PKCE)"""
 
     def __init__(self, identity_provider_url: str, scopes_retrieval: callable):
+        """
+        :param identity_provider_url: URL to retrieve the keys.
+            * Azure Active Directory: https://sts.windows.net/common/discovery/keys
+        :param scopes_retrieval: callable receiving the username and returning the list of associated scopes.
+        """
         self.identity_provider_url = identity_provider_url
         self.scopes_retrieval = scopes_retrieval
 

--- a/layabauth/starlette.py
+++ b/layabauth/starlette.py
@@ -1,0 +1,40 @@
+from typing import Optional, Tuple
+
+import jwt
+from starlette.authentication import (
+    AuthenticationBackend,
+    AuthCredentials,
+    BaseUser,
+    SimpleUser,
+    AuthenticationError,
+)
+from starlette.requests import Request
+
+from layabauth._authentication import _get_token, _to_user
+
+
+class OAuth2IdTokenBackend(AuthenticationBackend):
+    """Handle authentication via OAuth2 id-token (implicit flow, authorization code, with or without PKCE)"""
+
+    def __init__(self, identity_provider_url: str, scopes_retrieval: callable):
+        self.identity_provider_url = identity_provider_url
+        self.scopes_retrieval = scopes_retrieval
+
+    async def authenticate(
+        self, request: Request
+    ) -> Optional[Tuple["AuthCredentials", "BaseUser"]]:
+        token = _get_token(request.headers)
+        if not token:
+            return  # Consider that user is not authenticated
+
+        try:
+            user = _to_user(token, self.identity_provider_url)
+        except (
+            jwt.exceptions.InvalidTokenError or jwt.exceptions.InvalidKeyError
+        ) as e:
+            raise AuthenticationError(str(e)) from e
+
+        return (
+            AuthCredentials(scopes=self.scopes_retrieval(user.name)),
+            SimpleUser(user.name),
+        )

--- a/layabauth/starlette.py
+++ b/layabauth/starlette.py
@@ -19,20 +19,17 @@ class OAuth2IdTokenBackend(AuthenticationBackend):
     """
 
     def __init__(
-        self,
-        identity_provider_url: str,
-        create_user: callable,
-        scopes_retrieval: callable,
+        self, identity_provider_url: str, create_user: callable, scopes: callable
     ):
         """
         :param identity_provider_url: URL to retrieve the keys.
             * Azure Active Directory: https://sts.windows.net/common/discovery/keys
         :param create_user: callable receiving the token and the decoded token body and returning a starlette.BaseUser instance.
-        :param scopes_retrieval: callable receiving the decoded token body and returning the list of associated scopes str.
+        :param scopes: callable receiving the token and the decoded token body and returning the list of associated scopes str.
         """
         self.identity_provider_url = identity_provider_url
         self.create_user = create_user
-        self.scopes_retrieval = scopes_retrieval
+        self.scopes = scopes
 
     async def authenticate(
         self, request: Request
@@ -49,6 +46,6 @@ class OAuth2IdTokenBackend(AuthenticationBackend):
             raise AuthenticationError(str(e)) from e
 
         return (
-            AuthCredentials(scopes=self.scopes_retrieval(json_body)),
+            AuthCredentials(scopes=self.scopes(token=token, token_body=json_body)),
             self.create_user(token=token, token_body=json_body),
         )

--- a/layabauth/testing.py
+++ b/layabauth/testing.py
@@ -3,5 +3,7 @@ import oauth2helper
 
 
 @pytest.fixture
-def auth_mock(monkeypatch, upn):
-    monkeypatch.setattr(oauth2helper, "validate", lambda token, provider_url: ({}, {"upn": upn}))
+def auth_mock(monkeypatch, token_body: dict):
+    monkeypatch.setattr(
+        oauth2helper, "validate", lambda token, provider_url: ({}, token_body)
+    )

--- a/layabauth/version.py
+++ b/layabauth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "3.2.0"
+__version__ = "4.0.0"

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     extras_require={
         "testing": [
             # Used to test flask application
-            "flask==1.*",
+            "pytest-flask==1.*",
             # Used to test starlette authentication
             "starlette==0.13.*",
             "requests==2.*",

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     extras_require={
         "testing": [
             # Used to test flask application
+            "flask_restx==0.2.*",
             "pytest-flask==1.*",
             # Used to test starlette authentication
             "starlette==0.13.*",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Build Tools",
     ],
-    keywords=["flask"],
+    keywords=["flask", "starlette", "auth"],
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         # Used to manage authentication
@@ -40,6 +40,8 @@ setup(
     ],
     extras_require={
         "testing": [
+            # Used to test flask application
+            "flask==1.*",
             # Used to test starlette authentication
             "starlette==0.13.*",
             "requests==2.*",

--- a/setup.py
+++ b/setup.py
@@ -35,22 +35,19 @@ setup(
     keywords=["flask"],
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
-        # Used to manage received requests
-        "flask==1.*",
         # Used to manage authentication
-        "oauth2helper==3.*",
+        "oauth2helper==3.*"
     ],
     extras_require={
         "testing": [
-            # Used to manage testing of a Flask application
-            "pytest-flask==0.15.*",
-            # Used to test decorator
-            "flask-restplus==0.13.*",
+            # Used to test starlette authentication
+            "starlette==0.13.*",
+            "requests==2.*",
             # Used to mock requests sent to check keys
             "pytest-responses==0.4.*",
             # Used to check coverage
             "pytest-cov==2.*",
-        ],
+        ]
     },
     python_requires=">=3.6",
     project_urls={

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -368,13 +368,13 @@ def test_user_id_filter_with_value_already_set_in_flask_globals(client, auth_moc
     client.get("/requires_authentication")
 
     record = namedtuple("TestRecord", [])
-    layabauth.UserIdFilter("upn").filter(record)
+    layabauth.flask.UserIdFilter("upn").filter(record)
     assert record.user_id == "TEST"
 
 
 def test_user_id_filter_without_flask():
     record = namedtuple("TestRecord", [])
-    layabauth.UserIdFilter("upn").filter(record)
+    layabauth.flask.UserIdFilter("upn").filter(record)
     assert record.user_id == ""
 
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 
 import flask
-import flask_restplus
+import flask_restx
 
 import layabauth.flask
 from layabauth.testing import *
@@ -11,10 +11,10 @@ from layabauth.testing import *
 def app():
     application = flask.Flask(__name__)
     application.testing = True
-    api = flask_restplus.Api(application)
+    api = flask_restx.Api(application)
 
     @api.route("/requires_authentication")
-    class RequiresAuthentication(flask_restplus.Resource):
+    class RequiresAuthentication(flask_restx.Resource):
         @layabauth.flask.requires_authentication("https://test_identity_provider")
         def get(self):
             return "OK"
@@ -32,7 +32,7 @@ def app():
             return "OK"
 
     @api.route("/user_id")
-    class UserId(flask_restplus.Resource):
+    class UserId(flask_restx.Resource):
         def get(self):
             record = namedtuple("TestRecord", [])
             layabauth.flask.UserIdFilter("upn").filter(record)
@@ -361,7 +361,7 @@ def test_user_id_filter_with_value_set_in_header(client):
             "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"
         },
     )
-    assert response.get_data(as_text=True) == "JS5391"
+    assert response.get_data(as_text=True) == "JS5391@engie.com"
 
 
 def test_user_id_filter_with_value_already_set_in_flask_globals(client, auth_mock):
@@ -369,7 +369,7 @@ def test_user_id_filter_with_value_already_set_in_flask_globals(client, auth_moc
 
     record = namedtuple("TestRecord", [])
     layabauth.flask.UserIdFilter("upn").filter(record)
-    assert record.user_id == "TEST"
+    assert record.user_id == "TEST@email.com"
 
 
 def test_user_id_filter_without_flask():

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 import flask
 import flask_restplus
 
-import layabauth
+import layabauth.flask
 from layabauth.testing import *
 
 
@@ -15,19 +15,19 @@ def app():
 
     @api.route("/requires_authentication")
     class RequiresAuthentication(flask_restplus.Resource):
-        @layabauth.requires_authentication("https://test_identity_provider")
+        @layabauth.flask.requires_authentication("https://test_identity_provider")
         def get(self):
             return "OK"
 
-        @layabauth.requires_authentication("https://test_identity_provider")
+        @layabauth.flask.requires_authentication("https://test_identity_provider")
         def post(self):
             return "OK"
 
-        @layabauth.requires_authentication("https://test_identity_provider")
+        @layabauth.flask.requires_authentication("https://test_identity_provider")
         def put(self):
             return "OK"
 
-        @layabauth.requires_authentication("https://test_identity_provider")
+        @layabauth.flask.requires_authentication("https://test_identity_provider")
         def delete(self):
             return "OK"
 
@@ -35,7 +35,7 @@ def app():
     class UserId(flask_restplus.Resource):
         def get(self):
             record = namedtuple("TestRecord", [])
-            layabauth.UserIdFilter().filter(record)
+            layabauth.flask.UserIdFilter("upn").filter(record)
             return flask.make_response(str(record.user_id))
 
     return application
@@ -153,7 +153,9 @@ def test_authentication_failure_fake_token_provided_on_delete(client):
     }
 
 
-def test_authentication_failure_invalid_key_identifier_in_token_on_get(client, responses):
+def test_authentication_failure_invalid_key_identifier_in_token_on_get(
+    client, responses
+):
     responses.add(
         responses.GET,
         "https://test_identity_provider",
@@ -191,10 +193,14 @@ def test_authentication_failure_invalid_key_identifier_in_token_on_get(client, r
         },
     )
     assert response.status_code == 401
-    assert response.json == {'message': "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."}
+    assert response.json == {
+        "message": "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
+    }
 
 
-def test_authentication_failure_invalid_key_identifier_in_token_on_post(client, responses):
+def test_authentication_failure_invalid_key_identifier_in_token_on_post(
+    client, responses
+):
     responses.add(
         responses.GET,
         "https://test_identity_provider",
@@ -232,10 +238,14 @@ def test_authentication_failure_invalid_key_identifier_in_token_on_post(client, 
         },
     )
     assert response.status_code == 401
-    assert response.json == {'message': "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."}
+    assert response.json == {
+        "message": "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
+    }
 
 
-def test_authentication_failure_invalid_key_identifier_in_token_on_put(client, responses):
+def test_authentication_failure_invalid_key_identifier_in_token_on_put(
+    client, responses
+):
     responses.add(
         responses.GET,
         "https://test_identity_provider",
@@ -273,10 +283,14 @@ def test_authentication_failure_invalid_key_identifier_in_token_on_put(client, r
         },
     )
     assert response.status_code == 401
-    assert response.json == {'message': "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."}
+    assert response.json == {
+        "message": "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
+    }
 
 
-def test_authentication_failure_invalid_key_identifier_in_token_on_delete(client, responses):
+def test_authentication_failure_invalid_key_identifier_in_token_on_delete(
+    client, responses
+):
     responses.add(
         responses.GET,
         "https://test_identity_provider",
@@ -314,7 +328,9 @@ def test_authentication_failure_invalid_key_identifier_in_token_on_delete(client
         },
     )
     assert response.status_code == 401
-    assert response.json == {'message': "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."}
+    assert response.json == {
+        "message": "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
+    }
 
 
 def test_user_id_filter_with_value_not_set_in_header(client):
@@ -323,7 +339,10 @@ def test_user_id_filter_with_value_not_set_in_header(client):
 
 
 def test_user_id_filter_with_value_set_in_header(client):
-    response = client.get("/user_id", headers={"Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
+    response = client.get(
+        "/user_id",
+        headers={
+            "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
             "IsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiIyYmVmNzMzZC03NWJlLTQxNTktYj"
             "I4MC02NzJlMDU0OTM4YzMiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8yNDEzOWQxNC1jNjJjLTRjNDc"
             "tOGJkZC1jZTcxZWExZDUwY2YvIiwiaWF0IjoxNTIwMjcwNTAxLCJuYmYiOjE1MjAyNzA1MDEsImV4cCI6MTUyMDI3"
@@ -339,7 +358,9 @@ def test_user_id_filter_with_value_set_in_header(client):
             "ZT_vHvkZHFrmgfcTzED_AMdB9mTpvUm_Mk0d3F3RzLtyCeAApOPJaRAwccAc3PB1pKTwjFhdzIXtxib0_MQ6_F1fh"
             "b8R8ZcLCbwhMtT8nXoeWJOvH9_71O_vkfOn6E-VwLo17jkvQJOa89KfctGNnHNMcPBBju0oIgp_UVal311SMUw_10"
             "i4GZZkjR2I1m7EMg5jMwQgUatYWv2J5HoefAQQDat9jJeEnYNITxsJMN81FHTyuvMnN_ulFzOGtcvlBpmP6jVHfED"
-            "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"})
+            "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"
+        },
+    )
     assert response.get_data(as_text=True) == "JS5391"
 
 
@@ -347,37 +368,22 @@ def test_user_id_filter_with_value_already_set_in_flask_globals(client, auth_moc
     client.get("/requires_authentication")
 
     record = namedtuple("TestRecord", [])
-    layabauth.UserIdFilter().filter(record)
+    layabauth.UserIdFilter("upn").filter(record)
     assert record.user_id == "TEST"
 
 
 def test_user_id_filter_without_flask():
     record = namedtuple("TestRecord", [])
-    layabauth.UserIdFilter().filter(record)
+    layabauth.UserIdFilter("upn").filter(record)
     assert record.user_id == ""
 
 
 @pytest.fixture
-def upn():
-    return "TEST@email.com"
+def token_body():
+    return {"upn": "TEST@email.com"}
 
 
 def test_auth_mock(client, auth_mock):
     response = client.delete("/requires_authentication")
     assert response.status_code == 200
     assert response.get_data(as_text=True) == '"OK"\n'
-
-
-def test_method_authorizations():
-    assert layabauth.method_authorizations("test1", "test2") == {"security": [{"oauth2": ("test1", "test2")}]}
-
-
-def test_authorizations():
-    assert layabauth.authorizations("https://test_auth", test1="test1 desc", test2="test2 desc") == {
-        "oauth2": {
-            "scopes": {"test1": "test1 desc", "test2": "test2 desc"},
-            "flow": "implicit",
-            "authorizationUrl": "https://test_auth",
-            "type": "oauth2",
-        }
-    }

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,20 @@
+import layabauth
+
+
+def test_method_authorizations():
+    assert layabauth.method_authorizations("test1", "test2") == {
+        "security": [{"oauth2": ("test1", "test2")}]
+    }
+
+
+def test_authorizations():
+    assert layabauth.authorizations(
+        "https://test_auth", test1="test1 desc", test2="test2 desc"
+    ) == {
+        "oauth2": {
+            "scopes": {"test1": "test1 desc", "test2": "test2 desc"},
+            "flow": "implicit",
+            "authorizationUrl": "https://test_auth",
+            "type": "oauth2",
+        }
+    }

--- a/tests/test_starlette.py
+++ b/tests/test_starlette.py
@@ -1,0 +1,389 @@
+from collections import namedtuple
+
+import flask
+import flask_restplus
+
+import layabauth.flask
+from layabauth.testing import *
+
+
+@pytest.fixture
+def app():
+    application = flask.Flask(__name__)
+    application.testing = True
+    api = flask_restplus.Api(application)
+
+    @api.route("/requires_authentication")
+    class RequiresAuthentication(flask_restplus.Resource):
+        @layabauth.flask.requires_authentication("https://test_identity_provider")
+        def get(self):
+            return "OK"
+
+        @layabauth.flask.requires_authentication("https://test_identity_provider")
+        def post(self):
+            return "OK"
+
+        @layabauth.flask.requires_authentication("https://test_identity_provider")
+        def put(self):
+            return "OK"
+
+        @layabauth.flask.requires_authentication("https://test_identity_provider")
+        def delete(self):
+            return "OK"
+
+    @api.route("/user_id")
+    class UserId(flask_restplus.Resource):
+        def get(self):
+            record = namedtuple("TestRecord", [])
+            layabauth.flask.UserIdFilter("upn").filter(record)
+            return flask.make_response(str(record.user_id))
+
+    return application
+
+
+def test_generated_swagger(client):
+    response = client.get("/swagger.json")
+    assert response.status_code == 200
+    assert response.json == {
+        "swagger": "2.0",
+        "basePath": "/",
+        "paths": {
+            "/requires_authentication": {
+                "delete": {
+                    "responses": {"200": {"description": "Success"}},
+                    "operationId": "delete_requires_authentication",
+                    "tags": ["default"],
+                },
+                "get": {
+                    "responses": {"200": {"description": "Success"}},
+                    "operationId": "get_requires_authentication",
+                    "tags": ["default"],
+                },
+                "post": {
+                    "responses": {"200": {"description": "Success"}},
+                    "operationId": "post_requires_authentication",
+                    "tags": ["default"],
+                },
+                "put": {
+                    "responses": {"200": {"description": "Success"}},
+                    "operationId": "put_requires_authentication",
+                    "tags": ["default"],
+                },
+            },
+            "/user_id": {
+                "get": {
+                    "operationId": "get_user_id",
+                    "responses": {"200": {"description": "Success"}},
+                    "tags": ["default"],
+                }
+            },
+        },
+        "info": {"title": "API", "version": "1.0"},
+        "produces": ["application/json"],
+        "consumes": ["application/json"],
+        "tags": [{"name": "default", "description": "Default namespace"}],
+        "responses": {
+            "ParseError": {"description": "When a mask can't be parsed"},
+            "MaskError": {"description": "When any error occurs on mask"},
+        },
+    }
+
+
+def test_authentication_failure_token_not_provided_on_get(client):
+    response = client.get("/requires_authentication")
+    assert response.status_code == 401
+    assert response.json == {"message": "JWT Token is mandatory."}
+
+
+def test_authentication_failure_token_not_provided_on_post(client):
+    response = client.post("/requires_authentication")
+    assert response.status_code == 401
+    assert response.json == {"message": "JWT Token is mandatory."}
+
+
+def test_authentication_failure_token_not_provided_on_put(client):
+    response = client.put("/requires_authentication")
+    assert response.status_code == 401
+    assert response.json == {"message": "JWT Token is mandatory."}
+
+
+def test_authentication_failure_token_not_provided_on_delete(client):
+    response = client.delete("/requires_authentication")
+    assert response.status_code == 401
+    assert response.json == {"message": "JWT Token is mandatory."}
+
+
+def test_authentication_failure_fake_token_provided_on_get(client):
+    response = client.get(
+        "/requires_authentication", headers={"Authorization": "Bearer Fake token"}
+    )
+    assert response.status_code == 401
+    assert response.json == {
+        "message": "Invalid JWT Token (header, body and signature must be separated by dots)."
+    }
+
+
+def test_authentication_failure_fake_token_provided_on_post(client):
+    response = client.post(
+        "/requires_authentication", headers={"Authorization": "Bearer Fake token"}
+    )
+    assert response.status_code == 401
+    assert response.json == {
+        "message": "Invalid JWT Token (header, body and signature must be separated by dots)."
+    }
+
+
+def test_authentication_failure_fake_token_provided_on_put(client):
+    response = client.put(
+        "/requires_authentication", headers={"Authorization": "Bearer Fake token"}
+    )
+    assert response.status_code == 401
+    assert response.json == {
+        "message": "Invalid JWT Token (header, body and signature must be separated by dots)."
+    }
+
+
+def test_authentication_failure_fake_token_provided_on_delete(client):
+    response = client.delete(
+        "/requires_authentication", headers={"Authorization": "Bearer Fake token"}
+    )
+    assert response.status_code == 401
+    assert response.json == {
+        "message": "Invalid JWT Token (header, body and signature must be separated by dots)."
+    }
+
+
+def test_authentication_failure_invalid_key_identifier_in_token_on_get(
+    client, responses
+):
+    responses.add(
+        responses.GET,
+        "https://test_identity_provider",
+        json={
+            "keys": [
+                {
+                    "kid": "SSQdhI1cKvhQEDSJxE2gGYs40Q1",
+                    "x5c": [
+                        "MIIDBTCCAe2gAwIBAgIQdEMOjSqDVbdN3mzb2IumCzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDYwNDAwMDAwMFoXDTIxMDYwNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKEUUBvom99MdPXlrQ6S9MFmoQPoYI3NJVqEFOJcARY11dj3zyJogL8MTsTRt+DIJ8NyvYbgWC7K7zkAGzHQZhPJcM/AxSjFqh6qB98UqgxoSGBaG0A4lUZJHnKW3qx+YaiWrkg+z4sAwUkP0QgyI29Ejpkk6WUfe1rOJNc/defFUX+AVGxo81beLVAM/8tnCOSbF0H3IADwd76D/Hrp8RsGf4jPHr8N4VDsO/p7oj8rbOx0pL1ehjMK13zspmP8NO5mMcP9i5yiJ37FgbXESAxvja7I9t+y4LQYSu05M7la4Lqv//m5A8MBd6k0VxgF/Sq8GOIbkcQ0bJTCIN9B6oMCAwEAAaMhMB8wHQYDVR0OBBYEFNRP0Lf6MDeL11RDH0uL7H+/JqtLMA0GCSqGSIb3DQEBCwUAA4IBAQCJKR1nxp9Ij/yisCmDG7bdN1yHj/2HdVvyLfCCyReRfkB3cnTZVaIOBy5occGkdmsYJ+q8uqczkoCMAz3gvvq1c0msKEiNpqWNeU2aRXqyL3QZJ/GBmUK1I0tINPVv8j7znm0DcvHHXFvhzS8E4s8ai8vQkcpyac/7Z4PN43HtjDnkZo9Zxm7JahHshrhA8sSPvsuC4dQAcHbOrLbHG+HIo3Tq2pNl7mfQ9fVJ2FxbqlzPYr/rK8H2GTA6N55SuP3KTNvyL3RnMa3hXmGTdG1dpMFzD/IE623h/BqY6j29PyQC/+MUD4UCZ6KW9oIzpi27pKQagH1i1jpBU/ceH6AW"
+                    ],
+                }
+            ]
+        },
+    )
+    response = client.get(
+        "/requires_authentication",
+        headers={
+            "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
+            "IsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiIyYmVmNzMzZC03NWJlLTQxNTktYj"
+            "I4MC02NzJlMDU0OTM4YzMiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8yNDEzOWQxNC1jNjJjLTRjNDc"
+            "tOGJkZC1jZTcxZWExZDUwY2YvIiwiaWF0IjoxNTIwMjcwNTAxLCJuYmYiOjE1MjAyNzA1MDEsImV4cCI6MTUyMDI3"
+            "NDQwMSwiYWlvIjoiWTJOZ1lFaHlXMjYwVS9kR1RGeWNTMWNPVnczYnpqVXQ0Zk96TkNTekJYaWMyWTVOWFFNQSIsI"
+            "mFtciI6WyJwd2QiXSwiZmFtaWx5X25hbWUiOiJCb3Vub3VhciIsImdpdmVuX25hbWUiOiJDb2xpbiIsImlwYWRkci"
+            "I6IjE5NC4yOS45OC4xNDQiLCJuYW1lIjoiQm91bm91YXIgQ29saW4gKEVOR0lFIEVuZXJneSBNYW5hZ2VtZW50KSI"
+            "sIm5vbmNlIjoiW1x1MDAyNzczNjJDQUVBLTlDQTUtNEI0My05QkEzLTM0RDdDMzAzRUJBN1x1MDAyN10iLCJvaWQi"
+            "OiJkZTZiOGVjYS01ZTEzLTRhZTEtODcyMS1mZGNmNmI0YTljZGQiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMTQwO"
+            "TA4MjIzMy0xNDE3MDAxMzMzLTY4MjAwMzMzMC0zNzY5NTQiLCJzdWIiOiI2eEZSV1FBaElOZ0I4Vy10MnJRVUJzcE"
+            "lGc1VyUXQ0UUZ1V1VkSmRxWFdnIiwidGlkIjoiMjQxMzlkMTQtYzYyYy00YzQ3LThiZGQtY2U3MWVhMWQ1MGNmIiw"
+            "idW5pcXVlX25hbWUiOiJKUzUzOTFAZW5naWUuY29tIiwidXBuIjoiSlM1MzkxQGVuZ2llLmNvbSIsInV0aSI6InVm"
+            "M0x0X1Q5aWsyc0hGQ01oNklhQUEiLCJ2ZXIiOiIxLjAifQ.addwLSoO-2t1kXgljqnaU-P1hQGHQBiJMcNCLwELhB"
+            "ZT_vHvkZHFrmgfcTzED_AMdB9mTpvUm_Mk0d3F3RzLtyCeAApOPJaRAwccAc3PB1pKTwjFhdzIXtxib0_MQ6_F1fh"
+            "b8R8ZcLCbwhMtT8nXoeWJOvH9_71O_vkfOn6E-VwLo17jkvQJOa89KfctGNnHNMcPBBju0oIgp_UVal311SMUw_10"
+            "i4GZZkjR2I1m7EMg5jMwQgUatYWv2J5HoefAQQDat9jJeEnYNITxsJMN81FHTyuvMnN_ulFzOGtcvlBpmP6jVHfED"
+            "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"
+        },
+    )
+    assert response.status_code == 401
+    assert response.json == {
+        "message": "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
+    }
+
+
+def test_authentication_failure_invalid_key_identifier_in_token_on_post(
+    client, responses
+):
+    responses.add(
+        responses.GET,
+        "https://test_identity_provider",
+        json={
+            "keys": [
+                {
+                    "kid": "SSQdhI1cKvhQEDSJxE2gGYs40Q1",
+                    "x5c": [
+                        "MIIDBTCCAe2gAwIBAgIQdEMOjSqDVbdN3mzb2IumCzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDYwNDAwMDAwMFoXDTIxMDYwNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKEUUBvom99MdPXlrQ6S9MFmoQPoYI3NJVqEFOJcARY11dj3zyJogL8MTsTRt+DIJ8NyvYbgWC7K7zkAGzHQZhPJcM/AxSjFqh6qB98UqgxoSGBaG0A4lUZJHnKW3qx+YaiWrkg+z4sAwUkP0QgyI29Ejpkk6WUfe1rOJNc/defFUX+AVGxo81beLVAM/8tnCOSbF0H3IADwd76D/Hrp8RsGf4jPHr8N4VDsO/p7oj8rbOx0pL1ehjMK13zspmP8NO5mMcP9i5yiJ37FgbXESAxvja7I9t+y4LQYSu05M7la4Lqv//m5A8MBd6k0VxgF/Sq8GOIbkcQ0bJTCIN9B6oMCAwEAAaMhMB8wHQYDVR0OBBYEFNRP0Lf6MDeL11RDH0uL7H+/JqtLMA0GCSqGSIb3DQEBCwUAA4IBAQCJKR1nxp9Ij/yisCmDG7bdN1yHj/2HdVvyLfCCyReRfkB3cnTZVaIOBy5occGkdmsYJ+q8uqczkoCMAz3gvvq1c0msKEiNpqWNeU2aRXqyL3QZJ/GBmUK1I0tINPVv8j7znm0DcvHHXFvhzS8E4s8ai8vQkcpyac/7Z4PN43HtjDnkZo9Zxm7JahHshrhA8sSPvsuC4dQAcHbOrLbHG+HIo3Tq2pNl7mfQ9fVJ2FxbqlzPYr/rK8H2GTA6N55SuP3KTNvyL3RnMa3hXmGTdG1dpMFzD/IE623h/BqY6j29PyQC/+MUD4UCZ6KW9oIzpi27pKQagH1i1jpBU/ceH6AW"
+                    ],
+                }
+            ]
+        },
+    )
+    response = client.post(
+        "/requires_authentication",
+        headers={
+            "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
+            "IsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiIyYmVmNzMzZC03NWJlLTQxNTktYj"
+            "I4MC02NzJlMDU0OTM4YzMiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8yNDEzOWQxNC1jNjJjLTRjNDc"
+            "tOGJkZC1jZTcxZWExZDUwY2YvIiwiaWF0IjoxNTIwMjcwNTAxLCJuYmYiOjE1MjAyNzA1MDEsImV4cCI6MTUyMDI3"
+            "NDQwMSwiYWlvIjoiWTJOZ1lFaHlXMjYwVS9kR1RGeWNTMWNPVnczYnpqVXQ0Zk96TkNTekJYaWMyWTVOWFFNQSIsI"
+            "mFtciI6WyJwd2QiXSwiZmFtaWx5X25hbWUiOiJCb3Vub3VhciIsImdpdmVuX25hbWUiOiJDb2xpbiIsImlwYWRkci"
+            "I6IjE5NC4yOS45OC4xNDQiLCJuYW1lIjoiQm91bm91YXIgQ29saW4gKEVOR0lFIEVuZXJneSBNYW5hZ2VtZW50KSI"
+            "sIm5vbmNlIjoiW1x1MDAyNzczNjJDQUVBLTlDQTUtNEI0My05QkEzLTM0RDdDMzAzRUJBN1x1MDAyN10iLCJvaWQi"
+            "OiJkZTZiOGVjYS01ZTEzLTRhZTEtODcyMS1mZGNmNmI0YTljZGQiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMTQwO"
+            "TA4MjIzMy0xNDE3MDAxMzMzLTY4MjAwMzMzMC0zNzY5NTQiLCJzdWIiOiI2eEZSV1FBaElOZ0I4Vy10MnJRVUJzcE"
+            "lGc1VyUXQ0UUZ1V1VkSmRxWFdnIiwidGlkIjoiMjQxMzlkMTQtYzYyYy00YzQ3LThiZGQtY2U3MWVhMWQ1MGNmIiw"
+            "idW5pcXVlX25hbWUiOiJKUzUzOTFAZW5naWUuY29tIiwidXBuIjoiSlM1MzkxQGVuZ2llLmNvbSIsInV0aSI6InVm"
+            "M0x0X1Q5aWsyc0hGQ01oNklhQUEiLCJ2ZXIiOiIxLjAifQ.addwLSoO-2t1kXgljqnaU-P1hQGHQBiJMcNCLwELhB"
+            "ZT_vHvkZHFrmgfcTzED_AMdB9mTpvUm_Mk0d3F3RzLtyCeAApOPJaRAwccAc3PB1pKTwjFhdzIXtxib0_MQ6_F1fh"
+            "b8R8ZcLCbwhMtT8nXoeWJOvH9_71O_vkfOn6E-VwLo17jkvQJOa89KfctGNnHNMcPBBju0oIgp_UVal311SMUw_10"
+            "i4GZZkjR2I1m7EMg5jMwQgUatYWv2J5HoefAQQDat9jJeEnYNITxsJMN81FHTyuvMnN_ulFzOGtcvlBpmP6jVHfED"
+            "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"
+        },
+    )
+    assert response.status_code == 401
+    assert response.json == {
+        "message": "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
+    }
+
+
+def test_authentication_failure_invalid_key_identifier_in_token_on_put(
+    client, responses
+):
+    responses.add(
+        responses.GET,
+        "https://test_identity_provider",
+        json={
+            "keys": [
+                {
+                    "kid": "SSQdhI1cKvhQEDSJxE2gGYs40Q1",
+                    "x5c": [
+                        "MIIDBTCCAe2gAwIBAgIQdEMOjSqDVbdN3mzb2IumCzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDYwNDAwMDAwMFoXDTIxMDYwNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKEUUBvom99MdPXlrQ6S9MFmoQPoYI3NJVqEFOJcARY11dj3zyJogL8MTsTRt+DIJ8NyvYbgWC7K7zkAGzHQZhPJcM/AxSjFqh6qB98UqgxoSGBaG0A4lUZJHnKW3qx+YaiWrkg+z4sAwUkP0QgyI29Ejpkk6WUfe1rOJNc/defFUX+AVGxo81beLVAM/8tnCOSbF0H3IADwd76D/Hrp8RsGf4jPHr8N4VDsO/p7oj8rbOx0pL1ehjMK13zspmP8NO5mMcP9i5yiJ37FgbXESAxvja7I9t+y4LQYSu05M7la4Lqv//m5A8MBd6k0VxgF/Sq8GOIbkcQ0bJTCIN9B6oMCAwEAAaMhMB8wHQYDVR0OBBYEFNRP0Lf6MDeL11RDH0uL7H+/JqtLMA0GCSqGSIb3DQEBCwUAA4IBAQCJKR1nxp9Ij/yisCmDG7bdN1yHj/2HdVvyLfCCyReRfkB3cnTZVaIOBy5occGkdmsYJ+q8uqczkoCMAz3gvvq1c0msKEiNpqWNeU2aRXqyL3QZJ/GBmUK1I0tINPVv8j7znm0DcvHHXFvhzS8E4s8ai8vQkcpyac/7Z4PN43HtjDnkZo9Zxm7JahHshrhA8sSPvsuC4dQAcHbOrLbHG+HIo3Tq2pNl7mfQ9fVJ2FxbqlzPYr/rK8H2GTA6N55SuP3KTNvyL3RnMa3hXmGTdG1dpMFzD/IE623h/BqY6j29PyQC/+MUD4UCZ6KW9oIzpi27pKQagH1i1jpBU/ceH6AW"
+                    ],
+                }
+            ]
+        },
+    )
+    response = client.put(
+        "/requires_authentication",
+        headers={
+            "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
+            "IsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiIyYmVmNzMzZC03NWJlLTQxNTktYj"
+            "I4MC02NzJlMDU0OTM4YzMiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8yNDEzOWQxNC1jNjJjLTRjNDc"
+            "tOGJkZC1jZTcxZWExZDUwY2YvIiwiaWF0IjoxNTIwMjcwNTAxLCJuYmYiOjE1MjAyNzA1MDEsImV4cCI6MTUyMDI3"
+            "NDQwMSwiYWlvIjoiWTJOZ1lFaHlXMjYwVS9kR1RGeWNTMWNPVnczYnpqVXQ0Zk96TkNTekJYaWMyWTVOWFFNQSIsI"
+            "mFtciI6WyJwd2QiXSwiZmFtaWx5X25hbWUiOiJCb3Vub3VhciIsImdpdmVuX25hbWUiOiJDb2xpbiIsImlwYWRkci"
+            "I6IjE5NC4yOS45OC4xNDQiLCJuYW1lIjoiQm91bm91YXIgQ29saW4gKEVOR0lFIEVuZXJneSBNYW5hZ2VtZW50KSI"
+            "sIm5vbmNlIjoiW1x1MDAyNzczNjJDQUVBLTlDQTUtNEI0My05QkEzLTM0RDdDMzAzRUJBN1x1MDAyN10iLCJvaWQi"
+            "OiJkZTZiOGVjYS01ZTEzLTRhZTEtODcyMS1mZGNmNmI0YTljZGQiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMTQwO"
+            "TA4MjIzMy0xNDE3MDAxMzMzLTY4MjAwMzMzMC0zNzY5NTQiLCJzdWIiOiI2eEZSV1FBaElOZ0I4Vy10MnJRVUJzcE"
+            "lGc1VyUXQ0UUZ1V1VkSmRxWFdnIiwidGlkIjoiMjQxMzlkMTQtYzYyYy00YzQ3LThiZGQtY2U3MWVhMWQ1MGNmIiw"
+            "idW5pcXVlX25hbWUiOiJKUzUzOTFAZW5naWUuY29tIiwidXBuIjoiSlM1MzkxQGVuZ2llLmNvbSIsInV0aSI6InVm"
+            "M0x0X1Q5aWsyc0hGQ01oNklhQUEiLCJ2ZXIiOiIxLjAifQ.addwLSoO-2t1kXgljqnaU-P1hQGHQBiJMcNCLwELhB"
+            "ZT_vHvkZHFrmgfcTzED_AMdB9mTpvUm_Mk0d3F3RzLtyCeAApOPJaRAwccAc3PB1pKTwjFhdzIXtxib0_MQ6_F1fh"
+            "b8R8ZcLCbwhMtT8nXoeWJOvH9_71O_vkfOn6E-VwLo17jkvQJOa89KfctGNnHNMcPBBju0oIgp_UVal311SMUw_10"
+            "i4GZZkjR2I1m7EMg5jMwQgUatYWv2J5HoefAQQDat9jJeEnYNITxsJMN81FHTyuvMnN_ulFzOGtcvlBpmP6jVHfED"
+            "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"
+        },
+    )
+    assert response.status_code == 401
+    assert response.json == {
+        "message": "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
+    }
+
+
+def test_authentication_failure_invalid_key_identifier_in_token_on_delete(
+    client, responses
+):
+    responses.add(
+        responses.GET,
+        "https://test_identity_provider",
+        json={
+            "keys": [
+                {
+                    "kid": "SSQdhI1cKvhQEDSJxE2gGYs40Q1",
+                    "x5c": [
+                        "MIIDBTCCAe2gAwIBAgIQdEMOjSqDVbdN3mzb2IumCzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDYwNDAwMDAwMFoXDTIxMDYwNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKEUUBvom99MdPXlrQ6S9MFmoQPoYI3NJVqEFOJcARY11dj3zyJogL8MTsTRt+DIJ8NyvYbgWC7K7zkAGzHQZhPJcM/AxSjFqh6qB98UqgxoSGBaG0A4lUZJHnKW3qx+YaiWrkg+z4sAwUkP0QgyI29Ejpkk6WUfe1rOJNc/defFUX+AVGxo81beLVAM/8tnCOSbF0H3IADwd76D/Hrp8RsGf4jPHr8N4VDsO/p7oj8rbOx0pL1ehjMK13zspmP8NO5mMcP9i5yiJ37FgbXESAxvja7I9t+y4LQYSu05M7la4Lqv//m5A8MBd6k0VxgF/Sq8GOIbkcQ0bJTCIN9B6oMCAwEAAaMhMB8wHQYDVR0OBBYEFNRP0Lf6MDeL11RDH0uL7H+/JqtLMA0GCSqGSIb3DQEBCwUAA4IBAQCJKR1nxp9Ij/yisCmDG7bdN1yHj/2HdVvyLfCCyReRfkB3cnTZVaIOBy5occGkdmsYJ+q8uqczkoCMAz3gvvq1c0msKEiNpqWNeU2aRXqyL3QZJ/GBmUK1I0tINPVv8j7znm0DcvHHXFvhzS8E4s8ai8vQkcpyac/7Z4PN43HtjDnkZo9Zxm7JahHshrhA8sSPvsuC4dQAcHbOrLbHG+HIo3Tq2pNl7mfQ9fVJ2FxbqlzPYr/rK8H2GTA6N55SuP3KTNvyL3RnMa3hXmGTdG1dpMFzD/IE623h/BqY6j29PyQC/+MUD4UCZ6KW9oIzpi27pKQagH1i1jpBU/ceH6AW"
+                    ],
+                }
+            ]
+        },
+    )
+    response = client.delete(
+        "/requires_authentication",
+        headers={
+            "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
+            "IsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiIyYmVmNzMzZC03NWJlLTQxNTktYj"
+            "I4MC02NzJlMDU0OTM4YzMiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8yNDEzOWQxNC1jNjJjLTRjNDc"
+            "tOGJkZC1jZTcxZWExZDUwY2YvIiwiaWF0IjoxNTIwMjcwNTAxLCJuYmYiOjE1MjAyNzA1MDEsImV4cCI6MTUyMDI3"
+            "NDQwMSwiYWlvIjoiWTJOZ1lFaHlXMjYwVS9kR1RGeWNTMWNPVnczYnpqVXQ0Zk96TkNTekJYaWMyWTVOWFFNQSIsI"
+            "mFtciI6WyJwd2QiXSwiZmFtaWx5X25hbWUiOiJCb3Vub3VhciIsImdpdmVuX25hbWUiOiJDb2xpbiIsImlwYWRkci"
+            "I6IjE5NC4yOS45OC4xNDQiLCJuYW1lIjoiQm91bm91YXIgQ29saW4gKEVOR0lFIEVuZXJneSBNYW5hZ2VtZW50KSI"
+            "sIm5vbmNlIjoiW1x1MDAyNzczNjJDQUVBLTlDQTUtNEI0My05QkEzLTM0RDdDMzAzRUJBN1x1MDAyN10iLCJvaWQi"
+            "OiJkZTZiOGVjYS01ZTEzLTRhZTEtODcyMS1mZGNmNmI0YTljZGQiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMTQwO"
+            "TA4MjIzMy0xNDE3MDAxMzMzLTY4MjAwMzMzMC0zNzY5NTQiLCJzdWIiOiI2eEZSV1FBaElOZ0I4Vy10MnJRVUJzcE"
+            "lGc1VyUXQ0UUZ1V1VkSmRxWFdnIiwidGlkIjoiMjQxMzlkMTQtYzYyYy00YzQ3LThiZGQtY2U3MWVhMWQ1MGNmIiw"
+            "idW5pcXVlX25hbWUiOiJKUzUzOTFAZW5naWUuY29tIiwidXBuIjoiSlM1MzkxQGVuZ2llLmNvbSIsInV0aSI6InVm"
+            "M0x0X1Q5aWsyc0hGQ01oNklhQUEiLCJ2ZXIiOiIxLjAifQ.addwLSoO-2t1kXgljqnaU-P1hQGHQBiJMcNCLwELhB"
+            "ZT_vHvkZHFrmgfcTzED_AMdB9mTpvUm_Mk0d3F3RzLtyCeAApOPJaRAwccAc3PB1pKTwjFhdzIXtxib0_MQ6_F1fh"
+            "b8R8ZcLCbwhMtT8nXoeWJOvH9_71O_vkfOn6E-VwLo17jkvQJOa89KfctGNnHNMcPBBju0oIgp_UVal311SMUw_10"
+            "i4GZZkjR2I1m7EMg5jMwQgUatYWv2J5HoefAQQDat9jJeEnYNITxsJMN81FHTyuvMnN_ulFzOGtcvlBpmP6jVHfED"
+            "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"
+        },
+    )
+    assert response.status_code == 401
+    assert response.json == {
+        "message": "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
+    }
+
+
+def test_user_id_filter_with_value_not_set_in_header(client):
+    response = client.get("/user_id")
+    assert response.get_data(as_text=True) == ""
+
+
+def test_user_id_filter_with_value_set_in_header(client):
+    response = client.get(
+        "/user_id",
+        headers={
+            "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
+            "IsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiIyYmVmNzMzZC03NWJlLTQxNTktYj"
+            "I4MC02NzJlMDU0OTM4YzMiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8yNDEzOWQxNC1jNjJjLTRjNDc"
+            "tOGJkZC1jZTcxZWExZDUwY2YvIiwiaWF0IjoxNTIwMjcwNTAxLCJuYmYiOjE1MjAyNzA1MDEsImV4cCI6MTUyMDI3"
+            "NDQwMSwiYWlvIjoiWTJOZ1lFaHlXMjYwVS9kR1RGeWNTMWNPVnczYnpqVXQ0Zk96TkNTekJYaWMyWTVOWFFNQSIsI"
+            "mFtciI6WyJwd2QiXSwiZmFtaWx5X25hbWUiOiJCb3Vub3VhciIsImdpdmVuX25hbWUiOiJDb2xpbiIsImlwYWRkci"
+            "I6IjE5NC4yOS45OC4xNDQiLCJuYW1lIjoiQm91bm91YXIgQ29saW4gKEVOR0lFIEVuZXJneSBNYW5hZ2VtZW50KSI"
+            "sIm5vbmNlIjoiW1x1MDAyNzczNjJDQUVBLTlDQTUtNEI0My05QkEzLTM0RDdDMzAzRUJBN1x1MDAyN10iLCJvaWQi"
+            "OiJkZTZiOGVjYS01ZTEzLTRhZTEtODcyMS1mZGNmNmI0YTljZGQiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMTQwO"
+            "TA4MjIzMy0xNDE3MDAxMzMzLTY4MjAwMzMzMC0zNzY5NTQiLCJzdWIiOiI2eEZSV1FBaElOZ0I4Vy10MnJRVUJzcE"
+            "lGc1VyUXQ0UUZ1V1VkSmRxWFdnIiwidGlkIjoiMjQxMzlkMTQtYzYyYy00YzQ3LThiZGQtY2U3MWVhMWQ1MGNmIiw"
+            "idW5pcXVlX25hbWUiOiJKUzUzOTFAZW5naWUuY29tIiwidXBuIjoiSlM1MzkxQGVuZ2llLmNvbSIsInV0aSI6InVm"
+            "M0x0X1Q5aWsyc0hGQ01oNklhQUEiLCJ2ZXIiOiIxLjAifQ.addwLSoO-2t1kXgljqnaU-P1hQGHQBiJMcNCLwELhB"
+            "ZT_vHvkZHFrmgfcTzED_AMdB9mTpvUm_Mk0d3F3RzLtyCeAApOPJaRAwccAc3PB1pKTwjFhdzIXtxib0_MQ6_F1fh"
+            "b8R8ZcLCbwhMtT8nXoeWJOvH9_71O_vkfOn6E-VwLo17jkvQJOa89KfctGNnHNMcPBBju0oIgp_UVal311SMUw_10"
+            "i4GZZkjR2I1m7EMg5jMwQgUatYWv2J5HoefAQQDat9jJeEnYNITxsJMN81FHTyuvMnN_ulFzOGtcvlBpmP6jVHfED"
+            "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"
+        },
+    )
+    assert response.get_data(as_text=True) == "JS5391"
+
+
+def test_user_id_filter_with_value_already_set_in_flask_globals(client, auth_mock):
+    client.get("/requires_authentication")
+
+    record = namedtuple("TestRecord", [])
+    layabauth.UserIdFilter("upn").filter(record)
+    assert record.user_id == "TEST"
+
+
+def test_user_id_filter_without_flask():
+    record = namedtuple("TestRecord", [])
+    layabauth.UserIdFilter("upn").filter(record)
+    assert record.user_id == ""
+
+
+@pytest.fixture
+def token_body():
+    return {"upn": "TEST@email.com"}
+
+
+def test_auth_mock(client, auth_mock):
+    response = client.delete("/requires_authentication")
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == '"OK"\n'


### PR DESCRIPTION
### Changed
- Flask specifics are now within layabauth.flask.
- flask.g.current_user does not exists, instead, the validated token and the decoded token body are available in flask.g.token and flask.g.token_body
- `upn` field is not expected in token anymore. It is now up to the user to select what information they want to extract from the decoded token body.
- `UserIdFilter` class now requires `token_field_name` parameter to know what token body field value must be set inside `user_id`.
- `auth_mock` fixture now expects `token_body` fixture providing the decoded token body instead of `upn` fixture.
