### PR TITLE
Release 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drop oauth2helper in favor of python-jose to handle all kind of tokens.
 
 ### Changed
-- `identity_provider_url` pytest fixture needs to be provided in addition to `token_body`.
+- `identity_provider_url` has been renamed to `jwks_uri` to match the key in .well-known
+- `jwks_uri` pytest fixture needs to be provided in addition to `token_body`.
 - Flask tests will require a fake token to be provided in headers (unless you want to test behavior without providing a token).
 
 ## [4.0.0] - 2020-04-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1] - 2020-04-28
+### Fixed
+- Drop oauth2helper in favor of python-jose to handle all kind of tokens.
+
+### Changed
+- `identity_provider_url` pytest fixture needs to be provided in addition to `token_body`.
+- Flask tests will require a fake token to be provided in headers (unless you want to test behavior without providing a token).
+
 ## [4.0.0] - 2020-04-20
 ### Changed
 - Flask specifics are now within layabauth.flask.
@@ -18,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/layabauth/compare/v4.0.0...HEAD
+[Unreleased]: https://github.com/Colin-b/layabauth/compare/v4.0.1...HEAD
+[4.0.1]: https://github.com/Colin-b/layabauth/compare/v4.0.0...v4.0.1
 [4.0.0]: https://github.com/Colin-b/layabauth/compare/v3.2.0...v4.0.0
 [3.2.0]: https://github.com/Colin-b/layabauth/releases/tag/v3.2.0

--- a/README.md
+++ b/README.md
@@ -86,9 +86,16 @@ You can generate OpenAPI 2.0 `method security` thanks to `layabauth.method_autho
 Authentication can be mocked using `layabauth.testing.auth_mock` `pytest` fixture.
 
 `token_body` `pytest` fixture returning the decoded token body used in tests must be provided.
+`identity_provider_url` `pytest` fixture returning the identity_provider_url used in tests must be provided.
 
 ```python
 from layabauth.testing import *
+
+
+@pytest.fixture
+def identity_provider_url():
+    return "https://sts.windows.net/common/discovery/keys"
+
 
 @pytest.fixture
 def token_body():

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Token will then be validated and in case it is valid, you will be able to access
 Provides a [Starlette authentication backend](https://www.starlette.io/authentication/): `layabauth.starlette.OAuth2IdTokenBackend`.
 
 3 arguments are required:
-* The identity provided URL to validate the token key.
+* The [JWKs](https://tools.ietf.org/html/rfc7517) URI as defined in .well-known.
+ - Azure Active Directory: `https://sts.windows.net/common/discovery/keys`
+ - Microsoft Identity Platform: `https://sts.windows.net/common/discovery/keys`
 * A callable to create the [authenticated user](https://www.starlette.io/authentication/#users) based on received token.
 * A callable to returns [authenticated user scopes](https://www.starlette.io/authentication/#permissions) based on received token.
 
@@ -34,7 +36,7 @@ from starlette.responses import PlainTextResponse
 import layabauth.starlette
 
 backend = layabauth.starlette.OAuth2IdTokenBackend(
-    identity_provider_url="https://sts.windows.net/common/discovery/keys",
+    jwks_uri="https://sts.windows.net/common/discovery/keys",
     create_user=lambda token, token_body: SimpleUser(token_body["name"]),
     scopes=lambda token, token_body: ["my_scope"]
 )
@@ -50,8 +52,9 @@ async def my_endpoint(request):
 
 Provides a decorator `layabauth.flask.requires_authentication` to ensure that, in a context of a `Flask` application, a valid OAuth2 token was received.
 
-1 argument is required:
-* The identity provided URL to validate the token key.
+The [JWKs](https://tools.ietf.org/html/rfc7517) URI as defined in .well-known is the only required argument.
+- Azure Active Directory: `https://sts.windows.net/common/discovery/keys`
+- Microsoft Identity Platform: `https://sts.windows.net/common/discovery/keys`
 
 If validation fails, an `werkzeug.exceptions.Unauthorized` exception is raised.
 Otherwise token is stored in `flask.g.token` and decoded token body is stored in `flask.g.token_body`.
@@ -86,14 +89,14 @@ You can generate OpenAPI 2.0 `method security` thanks to `layabauth.method_autho
 Authentication can be mocked using `layabauth.testing.auth_mock` `pytest` fixture.
 
 `token_body` `pytest` fixture returning the decoded token body used in tests must be provided.
-`identity_provider_url` `pytest` fixture returning the identity_provider_url used in tests must be provided.
+`jwks_uri` `pytest` fixture returning the jwks_uri used in tests must be provided.
 
 ```python
 from layabauth.testing import *
 
 
 @pytest.fixture
-def identity_provider_url():
+def jwks_uri():
     return "https://sts.windows.net/common/discovery/keys"
 
 

--- a/layabauth/_http.py
+++ b/layabauth/_http.py
@@ -1,7 +1,28 @@
 from typing import Mapping
 
+import requests
+from jose import jwt, exceptions
+
 
 def _get_token(headers: Mapping[str, str]):
     authorization = headers.get("Authorization")
     if authorization and authorization.startswith("Bearer "):
         return authorization[7:]
+
+
+def validate(token: str, keys_url: str) -> dict:
+    try:
+        keys = requests.get(keys_url, verify=False)
+    except requests.RequestException as e:
+        raise exceptions.JOSEError(
+            f"{type(e).__name__} error while retrieving keys: {str(e)}"
+        )
+
+    if not keys:
+        raise exceptions.JOSEError(
+            f"HTTP {keys.status_code} error while retrieving keys: {keys.text}"
+        )
+
+    return jwt.decode(
+        token=token, key=keys.text, algorithms=["RS256"], options={"verify_aud": False}
+    )

--- a/layabauth/_http.py
+++ b/layabauth/_http.py
@@ -17,9 +17,9 @@ def validate(token: str, key: str) -> dict:
 
 
 # TODO Cache keys for faster token validation
-def keys(jwks_url: str) -> str:
+def keys(jwks_uri: str) -> str:
     try:
-        response = requests.get(jwks_url, verify=False)
+        response = requests.get(jwks_uri, verify=False)
     except requests.RequestException as e:
         raise exceptions.JOSEError(
             f"{type(e).__name__} error while retrieving keys: {str(e)}"

--- a/layabauth/starlette.py
+++ b/layabauth/starlette.py
@@ -1,7 +1,5 @@
 from typing import Optional, Tuple
 
-import jwt
-import oauth2helper
 from starlette.authentication import (
     AuthenticationBackend,
     AuthCredentials,
@@ -9,8 +7,9 @@ from starlette.authentication import (
     AuthenticationError,
 )
 from starlette.requests import Request
+from jose import exceptions
 
-from layabauth._http import _get_token
+from layabauth._http import _get_token, validate
 
 
 class OAuth2IdTokenBackend(AuthenticationBackend):
@@ -39,10 +38,8 @@ class OAuth2IdTokenBackend(AuthenticationBackend):
             return  # Consider that user is not authenticated
 
         try:
-            json_header, json_body = oauth2helper.validate(
-                token, self.identity_provider_url
-            )
-        except jwt.PyJWTError as e:
+            json_body = validate(token, self.identity_provider_url)
+        except exceptions.JOSEError as e:
             raise AuthenticationError(str(e)) from e
 
         return (

--- a/layabauth/starlette.py
+++ b/layabauth/starlette.py
@@ -9,7 +9,7 @@ from starlette.authentication import (
 from starlette.requests import Request
 from jose import exceptions
 
-from layabauth._http import _get_token, validate
+from layabauth._http import _get_token, validate, keys
 
 
 class OAuth2IdTokenBackend(AuthenticationBackend):
@@ -17,16 +17,16 @@ class OAuth2IdTokenBackend(AuthenticationBackend):
     Handle authentication via OAuth2 id-token (implicit flow, authorization code, with or without PKCE)
     """
 
-    def __init__(
-        self, identity_provider_url: str, create_user: callable, scopes: callable
-    ):
+    def __init__(self, jwks_uri: str, create_user: callable, scopes: callable):
         """
-        :param identity_provider_url: URL to retrieve the keys.
+        :param jwks_uri: The JWKs URI as defined in .well-known.
+        For more information on JWK, refer to https://tools.ietf.org/html/rfc7517
             * Azure Active Directory: https://sts.windows.net/common/discovery/keys
+            * Microsoft Identity Platform: https://sts.windows.net/common/discovery/keys
         :param create_user: callable receiving the token and the decoded token body and returning a starlette.BaseUser instance.
         :param scopes: callable receiving the token and the decoded token body and returning the list of associated scopes str.
         """
-        self.identity_provider_url = identity_provider_url
+        self.jwks_uri = jwks_uri
         self.create_user = create_user
         self.scopes = scopes
 
@@ -38,7 +38,8 @@ class OAuth2IdTokenBackend(AuthenticationBackend):
             return  # Consider that user is not authenticated
 
         try:
-            json_body = validate(token, self.identity_provider_url)
+            key = keys(self.jwks_uri)
+            json_body = validate(token, key)
         except exceptions.JOSEError as e:
             raise AuthenticationError(str(e)) from e
 

--- a/layabauth/testing.py
+++ b/layabauth/testing.py
@@ -4,10 +4,10 @@ from responses import RequestsMock
 
 
 @pytest.fixture
-def auth_mock(
-    monkeypatch, responses: RequestsMock, token_body: dict, identity_provider_url: str
-):
-    responses.add(method=responses.GET, url=identity_provider_url)
+def auth_mock(monkeypatch, responses: RequestsMock, token_body: dict, jwks_uri: str):
+    # Mock keys
+    responses.add(method=responses.GET, url=jwks_uri)
+    # Mock token validation (TODO only deactivate validation so that clients can use raw tokens)
     monkeypatch.setattr(
         layabauth._http.jwt, "decode", lambda *args, **kwargs: token_body
     )

--- a/layabauth/testing.py
+++ b/layabauth/testing.py
@@ -1,9 +1,13 @@
 import pytest
-import oauth2helper
+import layabauth._http
+from responses import RequestsMock
 
 
 @pytest.fixture
-def auth_mock(monkeypatch, token_body: dict):
+def auth_mock(
+    monkeypatch, responses: RequestsMock, token_body: dict, identity_provider_url: str
+):
+    responses.add(method=responses.GET, url=identity_provider_url)
     monkeypatch.setattr(
-        oauth2helper, "validate", lambda token, provider_url: ({}, token_body)
+        layabauth._http.jwt, "decode", lambda *args, **kwargs: token_body
     )

--- a/layabauth/version.py
+++ b/layabauth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "4.0.0"
+__version__ = "4.0.1"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     maintainer="Colin Bounouar",
     maintainer_email="colin.bounouar.dev@gmail.com",
     url="https://colin-b.github.io/layabauth/",
-    description="Authentication support for layab.",
+    description="Handle OAuth2 authentication for REST APIs",
     long_description=long_description,
     long_description_content_type="text/markdown",
     download_url="https://pypi.org/project/layabauth/",

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,10 @@ setup(
     keywords=["flask", "starlette", "auth"],
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
+        # Used to request JWKs (keys)
+        "requests==2.*",
         # Used to manage authentication
-        "oauth2helper==3.*"
+        "python-jose==3.*",
     ],
     extras_require={
         "testing": [

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -237,7 +237,7 @@ def test_user_id_filter_without_flask():
 
 
 @pytest.fixture
-def identity_provider_url():
+def jwks_uri():
     return "https://test_identity_provider"
 
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -2,13 +2,15 @@ from collections import namedtuple
 
 import flask
 import flask_restx
+import requests
+import flask.testing
 
 import layabauth.flask
 from layabauth.testing import *
 
 
 @pytest.fixture
-def app():
+def app() -> flask.Flask:
     application = flask.Flask(__name__)
     application.testing = True
     api = flask_restx.Api(application)
@@ -17,19 +19,19 @@ def app():
     class RequiresAuthentication(flask_restx.Resource):
         @layabauth.flask.requires_authentication("https://test_identity_provider")
         def get(self):
-            return "OK"
+            return flask.g.token_body
 
         @layabauth.flask.requires_authentication("https://test_identity_provider")
         def post(self):
-            return "OK"
+            return flask.g.token_body
 
         @layabauth.flask.requires_authentication("https://test_identity_provider")
         def put(self):
-            return "OK"
+            return flask.g.token_body
 
         @layabauth.flask.requires_authentication("https://test_identity_provider")
         def delete(self):
-            return "OK"
+            return flask.g.token_body
 
     @api.route("/user_id")
     class UserId(flask_restx.Resource):
@@ -41,7 +43,7 @@ def app():
     return application
 
 
-def test_generated_swagger(client):
+def test_generated_swagger(client: flask.testing.FlaskClient):
     response = client.get("/swagger.json")
     assert response.status_code == 200
     assert response.json == {
@@ -89,89 +91,75 @@ def test_generated_swagger(client):
     }
 
 
-def test_authentication_failure_token_not_provided_on_get(client):
-    response = client.get("/requires_authentication")
-    assert response.status_code == 401
-    assert response.json == {"message": "JWT Token is mandatory."}
-
-
-def test_authentication_failure_token_not_provided_on_post(client):
-    response = client.post("/requires_authentication")
-    assert response.status_code == 401
-    assert response.json == {"message": "JWT Token is mandatory."}
-
-
-def test_authentication_failure_token_not_provided_on_put(client):
-    response = client.put("/requires_authentication")
-    assert response.status_code == 401
-    assert response.json == {"message": "JWT Token is mandatory."}
-
-
-def test_authentication_failure_token_not_provided_on_delete(client):
-    response = client.delete("/requires_authentication")
-    assert response.status_code == 401
-    assert response.json == {"message": "JWT Token is mandatory."}
-
-
-def test_authentication_failure_fake_token_provided_on_get(client):
-    response = client.get(
-        "/requires_authentication", headers={"Authorization": "Bearer Fake token"}
-    )
+@pytest.mark.parametrize("method", ["GET", "POST", "PUT", "DELETE"])
+def test_without_authentication_header(client: flask.testing.FlaskClient, method: str):
+    response = client.open(method=method, path="/requires_authentication")
     assert response.status_code == 401
     assert response.json == {
-        "message": "Invalid JWT Token (header, body and signature must be separated by dots)."
+        "message": "The server could not verify that you are authorized to access the URL requested. You either supplied the wrong credentials (e.g. a bad password), or your browser doesn't understand how to supply the credentials required."
     }
 
 
-def test_authentication_failure_fake_token_provided_on_post(client):
-    response = client.post(
-        "/requires_authentication", headers={"Authorization": "Bearer Fake token"}
-    )
-    assert response.status_code == 401
-    assert response.json == {
-        "message": "Invalid JWT Token (header, body and signature must be separated by dots)."
-    }
-
-
-def test_authentication_failure_fake_token_provided_on_put(client):
-    response = client.put(
-        "/requires_authentication", headers={"Authorization": "Bearer Fake token"}
-    )
-    assert response.status_code == 401
-    assert response.json == {
-        "message": "Invalid JWT Token (header, body and signature must be separated by dots)."
-    }
-
-
-def test_authentication_failure_fake_token_provided_on_delete(client):
-    response = client.delete(
-        "/requires_authentication", headers={"Authorization": "Bearer Fake token"}
-    )
-    assert response.status_code == 401
-    assert response.json == {
-        "message": "Invalid JWT Token (header, body and signature must be separated by dots)."
-    }
-
-
-def test_authentication_failure_invalid_key_identifier_in_token_on_get(
-    client, responses
+@pytest.mark.parametrize("method", ["GET", "POST", "PUT", "DELETE"])
+def test_with_non_jwt(
+    client: flask.testing.FlaskClient, responses: RequestsMock, method: str
 ):
+    responses.add(method=responses.GET, url="https://test_identity_provider")
+    response = client.open(
+        method=method,
+        path="/requires_authentication",
+        headers={"Authorization": "Bearer Fake token"},
+    )
+    assert response.status_code == 401
+    assert response.json == {"message": "Not enough segments"}
+
+
+@pytest.mark.parametrize("method", ["GET", "POST", "PUT", "DELETE"])
+def test_with_invalid_jwt(client: flask.testing.FlaskClient, responses, method: str):
     responses.add(
         responses.GET,
         "https://test_identity_provider",
         json={
             "keys": [
                 {
-                    "kid": "SSQdhI1cKvhQEDSJxE2gGYs40Q1",
+                    "kty": "RSA",
+                    "use": "sig",
+                    "kid": "CtTuhMJmD5M7DLdzD2v2x3QKSRY",
+                    "x5t": "CtTuhMJmD5M7DLdzD2v2x3QKSRY",
+                    "n": "18uZ3P3IgOySlnOsxeIN5WUKzvlm6evPDMFbmXPtTF0GMe7tD2JPfai2UGn74s7AFwqxWO5DQZRu6VfQUux8uMR4J7nxm1Kf__7pVEVJJyDuL5a8PARRYQtH68w-0IZxcFOkgsSdhtIzPQ2jj4mmRzWXIwh8M_8pJ6qiOjvjF9bhEq0CC_f27BnljPaFn8hxY69pCoxenWWqFcsUhFZvCMthhRubAbBilDr74KaXS5xCgySBhPzwekD9_NdCUuCsdqavd4T-VWnbplbB8YsC-R00FptBFKuTyT9zoGZjWZilQVmj7v3k8jXqYB2nWKgTAfwjmiyKz78FHkaE-nCIDw",
+                    "e": "AQAB",
                     "x5c": [
-                        "MIIDBTCCAe2gAwIBAgIQdEMOjSqDVbdN3mzb2IumCzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDYwNDAwMDAwMFoXDTIxMDYwNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKEUUBvom99MdPXlrQ6S9MFmoQPoYI3NJVqEFOJcARY11dj3zyJogL8MTsTRt+DIJ8NyvYbgWC7K7zkAGzHQZhPJcM/AxSjFqh6qB98UqgxoSGBaG0A4lUZJHnKW3qx+YaiWrkg+z4sAwUkP0QgyI29Ejpkk6WUfe1rOJNc/defFUX+AVGxo81beLVAM/8tnCOSbF0H3IADwd76D/Hrp8RsGf4jPHr8N4VDsO/p7oj8rbOx0pL1ehjMK13zspmP8NO5mMcP9i5yiJ37FgbXESAxvja7I9t+y4LQYSu05M7la4Lqv//m5A8MBd6k0VxgF/Sq8GOIbkcQ0bJTCIN9B6oMCAwEAAaMhMB8wHQYDVR0OBBYEFNRP0Lf6MDeL11RDH0uL7H+/JqtLMA0GCSqGSIb3DQEBCwUAA4IBAQCJKR1nxp9Ij/yisCmDG7bdN1yHj/2HdVvyLfCCyReRfkB3cnTZVaIOBy5occGkdmsYJ+q8uqczkoCMAz3gvvq1c0msKEiNpqWNeU2aRXqyL3QZJ/GBmUK1I0tINPVv8j7znm0DcvHHXFvhzS8E4s8ai8vQkcpyac/7Z4PN43HtjDnkZo9Zxm7JahHshrhA8sSPvsuC4dQAcHbOrLbHG+HIo3Tq2pNl7mfQ9fVJ2FxbqlzPYr/rK8H2GTA6N55SuP3KTNvyL3RnMa3hXmGTdG1dpMFzD/IE623h/BqY6j29PyQC/+MUD4UCZ6KW9oIzpi27pKQagH1i1jpBU/ceH6AW"
+                        "MIIDBTCCAe2gAwIBAgIQXVogj9BAf49IpuOSIvztNDANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTIwMDMxNzAwMDAwMFoXDTI1MDMxNzAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANfLmdz9yIDskpZzrMXiDeVlCs75ZunrzwzBW5lz7UxdBjHu7Q9iT32otlBp++LOwBcKsVjuQ0GUbulX0FLsfLjEeCe58ZtSn//+6VRFSScg7i+WvDwEUWELR+vMPtCGcXBTpILEnYbSMz0No4+Jpkc1lyMIfDP/KSeqojo74xfW4RKtAgv39uwZ5Yz2hZ/IcWOvaQqMXp1lqhXLFIRWbwjLYYUbmwGwYpQ6++Cml0ucQoMkgYT88HpA/fzXQlLgrHamr3eE/lVp26ZWwfGLAvkdNBabQRSrk8k/c6BmY1mYpUFZo+795PI16mAdp1ioEwH8I5osis+/BR5GhPpwiA8CAwEAAaMhMB8wHQYDVR0OBBYEFF8MDGklOGhGNVJvsHHRCaqtzexcMA0GCSqGSIb3DQEBCwUAA4IBAQCKkegw/mdpCVl1lOpgU4G9RT+1gtcPqZK9kpimuDggSJju6KUQlOCi5/lIH5DCzpjFdmG17TjWVBNve5kowmrhLzovY0Ykk7+6hYTBK8dNNSmd4SK7zY++0aDIuOzHP2Cur+kgFC0gez50tPzotLDtMmp40gknXuzltwJfezNSw3gLgljDsGGcDIXK3qLSYh44qSuRGwulcN2EJUZBI9tIxoODpaWHIN8+z2uZvf8JBYFjA3+n9FRQn51X16CTcjq4QRTbNVpgVuQuyaYnEtx0ZnDvguB3RjGSPIXTRBkLl2x7e8/6uAZ6tchw8rhcOtPsFgJuoJokGjvcUSR/6Eqd"
                     ],
-                }
+                },
+                {
+                    "kty": "RSA",
+                    "use": "sig",
+                    "kid": "SsZsBNhZcF3Q9S4trpQBTByNRRI",
+                    "x5t": "SsZsBNhZcF3Q9S4trpQBTByNRRI",
+                    "n": "uHPewhg4WC3eLVPkEFlj7RDtaKYWXCI5G-LPVzsMKOuIu7qQQbeytIA6P6HT9_iIRt8zNQvuw4P9vbNjgUCpI6vfZGsjk3XuCVoB_bAIhvuBcQh9ePH2yEwS5reR-NrG1PsqzobnZZuigKCoDmuOb_UDx1DiVyNCbMBlEG7UzTQwLf5NP6HaRHx027URJeZvPAWY7zjHlSOuKoS_d1yUveaBFIgZqPWLCg44ck4gvik45HsNVWT9zYfT74dvUSSrMSR-SHFT7Hy1XjbVXpHJHNNAXpPoGoWXTuc0BxMsB4cqjfJqoftFGOG4x32vEzakArLPxAKwGvkvu0jToAyvSQ",
+                    "e": "AQAB",
+                    "x5c": [
+                        "MIIDBTCCAe2gAwIBAgIQWHw7h/Ysh6hPcXpnrJ0N8DANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTIwMDQyNzAwMDAwMFoXDTI1MDQyNzAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALhz3sIYOFgt3i1T5BBZY+0Q7WimFlwiORviz1c7DCjriLu6kEG3srSAOj+h0/f4iEbfMzUL7sOD/b2zY4FAqSOr32RrI5N17glaAf2wCIb7gXEIfXjx9shMEua3kfjaxtT7Ks6G52WbooCgqA5rjm/1A8dQ4lcjQmzAZRBu1M00MC3+TT+h2kR8dNu1ESXmbzwFmO84x5UjriqEv3dclL3mgRSIGaj1iwoOOHJOIL4pOOR7DVVk/c2H0++Hb1EkqzEkfkhxU+x8tV421V6RyRzTQF6T6BqFl07nNAcTLAeHKo3yaqH7RRjhuMd9rxM2pAKyz8QCsBr5L7tI06AMr0kCAwEAAaMhMB8wHQYDVR0OBBYEFOI7M+DDFMlP7Ac3aomPnWo1QL1SMA0GCSqGSIb3DQEBCwUAA4IBAQBv+8rBiDY8sZDBoUDYwFQM74QjqCmgNQfv5B0Vjwg20HinERjQeH24uAWzyhWN9++FmeY4zcRXDY5UNmB0nJz7UGlprA9s7voQ0Lkyiud0DO072RPBg38LmmrqoBsLb3MB9MZ2CGBaHftUHfpdTvrgmXSP0IJn7mCUq27g+hFk7n/MLbN1k8JswEODIgdMRvGqN+mnrPKkviWmcVAZccsWfcmS1pKwXqICTKzd6WmVdz+cL7ZSd9I2X0pY4oRwauoE2bS95vrXljCYgLArI3XB2QcnglDDBRYu3Z3aIJb26PTIyhkVKT7xaXhXl4OgrbmQon9/O61G2dzpjzzBPqNP"
+                    ],
+                },
+                {
+                    "kty": "RSA",
+                    "use": "sig",
+                    "kid": "M6pX7RHoraLsprfJeRCjSxuURhc",
+                    "x5t": "M6pX7RHoraLsprfJeRCjSxuURhc",
+                    "n": "xHScZMPo8FifoDcrgncWQ7mGJtiKhrsho0-uFPXg-OdnRKYudTD7-Bq1MDjcqWRf3IfDVjFJixQS61M7wm9wALDj--lLuJJ9jDUAWTA3xWvQLbiBM-gqU0sj4mc2lWm6nPfqlyYeWtQcSC0sYkLlayNgX4noKDaXivhVOp7bwGXq77MRzeL4-9qrRYKjuzHfZL7kNBCsqO185P0NI2Jtmw-EsqYsrCaHsfNRGRrTvUHUq3hWa859kK_5uNd7TeY2ZEwKVD8ezCmSfR59ZzyxTtuPpkCSHS9OtUvS3mqTYit73qcvprjl3R8hpjXLb8oftfpWr3hFRdpxrwuoQEO4QQ",
+                    "e": "AQAB",
+                    "x5c": [
+                        "MIIC8TCCAdmgAwIBAgIQfEWlTVc1uINEc9RBi6qHMjANBgkqhkiG9w0BAQsFADAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwHhcNMTgxMDE0MDAwMDAwWhcNMjAxMDE0MDAwMDAwWjAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDEdJxkw+jwWJ+gNyuCdxZDuYYm2IqGuyGjT64U9eD452dEpi51MPv4GrUwONypZF/ch8NWMUmLFBLrUzvCb3AAsOP76Uu4kn2MNQBZMDfFa9AtuIEz6CpTSyPiZzaVabqc9+qXJh5a1BxILSxiQuVrI2BfiegoNpeK+FU6ntvAZervsxHN4vj72qtFgqO7Md9kvuQ0EKyo7Xzk/Q0jYm2bD4SypiysJoex81EZGtO9QdSreFZrzn2Qr/m413tN5jZkTApUPx7MKZJ9Hn1nPLFO24+mQJIdL061S9LeapNiK3vepy+muOXdHyGmNctvyh+1+laveEVF2nGvC6hAQ7hBAgMBAAGjITAfMB0GA1UdDgQWBBQ5TKadw06O0cvXrQbXW0Nb3M3h/DANBgkqhkiG9w0BAQsFAAOCAQEAI48JaFtwOFcYS/3pfS5+7cINrafXAKTL+/+he4q+RMx4TCu/L1dl9zS5W1BeJNO2GUznfI+b5KndrxdlB6qJIDf6TRHh6EqfA18oJP5NOiKhU4pgkF2UMUw4kjxaZ5fQrSoD9omjfHAFNjradnHA7GOAoF4iotvXDWDBWx9K4XNZHWvD11Td66zTg5IaEQDIZ+f8WS6nn/98nAVMDtR9zW7Te5h9kGJGfe6WiHVaGRPpBvqC4iypGHjbRwANwofZvmp5wP08hY1CsnKY5tfP+E2k/iAQgKKa6QoxXToYvP7rsSkglak8N5g/+FJGnq4wP6cOzgZpjdPMwaVt5432GA=="
+                    ],
+                },
             ]
         },
     )
-    response = client.get(
-        "/requires_authentication",
+    response = client.open(
+        method=method,
+        path="/requires_authentication",
         headers={
             "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
             "IsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiIyYmVmNzMzZC03NWJlLTQxNTktYj"
@@ -193,144 +181,7 @@ def test_authentication_failure_invalid_key_identifier_in_token_on_get(
         },
     )
     assert response.status_code == 401
-    assert response.json == {
-        "message": "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
-    }
-
-
-def test_authentication_failure_invalid_key_identifier_in_token_on_post(
-    client, responses
-):
-    responses.add(
-        responses.GET,
-        "https://test_identity_provider",
-        json={
-            "keys": [
-                {
-                    "kid": "SSQdhI1cKvhQEDSJxE2gGYs40Q1",
-                    "x5c": [
-                        "MIIDBTCCAe2gAwIBAgIQdEMOjSqDVbdN3mzb2IumCzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDYwNDAwMDAwMFoXDTIxMDYwNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKEUUBvom99MdPXlrQ6S9MFmoQPoYI3NJVqEFOJcARY11dj3zyJogL8MTsTRt+DIJ8NyvYbgWC7K7zkAGzHQZhPJcM/AxSjFqh6qB98UqgxoSGBaG0A4lUZJHnKW3qx+YaiWrkg+z4sAwUkP0QgyI29Ejpkk6WUfe1rOJNc/defFUX+AVGxo81beLVAM/8tnCOSbF0H3IADwd76D/Hrp8RsGf4jPHr8N4VDsO/p7oj8rbOx0pL1ehjMK13zspmP8NO5mMcP9i5yiJ37FgbXESAxvja7I9t+y4LQYSu05M7la4Lqv//m5A8MBd6k0VxgF/Sq8GOIbkcQ0bJTCIN9B6oMCAwEAAaMhMB8wHQYDVR0OBBYEFNRP0Lf6MDeL11RDH0uL7H+/JqtLMA0GCSqGSIb3DQEBCwUAA4IBAQCJKR1nxp9Ij/yisCmDG7bdN1yHj/2HdVvyLfCCyReRfkB3cnTZVaIOBy5occGkdmsYJ+q8uqczkoCMAz3gvvq1c0msKEiNpqWNeU2aRXqyL3QZJ/GBmUK1I0tINPVv8j7znm0DcvHHXFvhzS8E4s8ai8vQkcpyac/7Z4PN43HtjDnkZo9Zxm7JahHshrhA8sSPvsuC4dQAcHbOrLbHG+HIo3Tq2pNl7mfQ9fVJ2FxbqlzPYr/rK8H2GTA6N55SuP3KTNvyL3RnMa3hXmGTdG1dpMFzD/IE623h/BqY6j29PyQC/+MUD4UCZ6KW9oIzpi27pKQagH1i1jpBU/ceH6AW"
-                    ],
-                }
-            ]
-        },
-    )
-    response = client.post(
-        "/requires_authentication",
-        headers={
-            "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
-            "IsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiIyYmVmNzMzZC03NWJlLTQxNTktYj"
-            "I4MC02NzJlMDU0OTM4YzMiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8yNDEzOWQxNC1jNjJjLTRjNDc"
-            "tOGJkZC1jZTcxZWExZDUwY2YvIiwiaWF0IjoxNTIwMjcwNTAxLCJuYmYiOjE1MjAyNzA1MDEsImV4cCI6MTUyMDI3"
-            "NDQwMSwiYWlvIjoiWTJOZ1lFaHlXMjYwVS9kR1RGeWNTMWNPVnczYnpqVXQ0Zk96TkNTekJYaWMyWTVOWFFNQSIsI"
-            "mFtciI6WyJwd2QiXSwiZmFtaWx5X25hbWUiOiJCb3Vub3VhciIsImdpdmVuX25hbWUiOiJDb2xpbiIsImlwYWRkci"
-            "I6IjE5NC4yOS45OC4xNDQiLCJuYW1lIjoiQm91bm91YXIgQ29saW4gKEVOR0lFIEVuZXJneSBNYW5hZ2VtZW50KSI"
-            "sIm5vbmNlIjoiW1x1MDAyNzczNjJDQUVBLTlDQTUtNEI0My05QkEzLTM0RDdDMzAzRUJBN1x1MDAyN10iLCJvaWQi"
-            "OiJkZTZiOGVjYS01ZTEzLTRhZTEtODcyMS1mZGNmNmI0YTljZGQiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMTQwO"
-            "TA4MjIzMy0xNDE3MDAxMzMzLTY4MjAwMzMzMC0zNzY5NTQiLCJzdWIiOiI2eEZSV1FBaElOZ0I4Vy10MnJRVUJzcE"
-            "lGc1VyUXQ0UUZ1V1VkSmRxWFdnIiwidGlkIjoiMjQxMzlkMTQtYzYyYy00YzQ3LThiZGQtY2U3MWVhMWQ1MGNmIiw"
-            "idW5pcXVlX25hbWUiOiJKUzUzOTFAZW5naWUuY29tIiwidXBuIjoiSlM1MzkxQGVuZ2llLmNvbSIsInV0aSI6InVm"
-            "M0x0X1Q5aWsyc0hGQ01oNklhQUEiLCJ2ZXIiOiIxLjAifQ.addwLSoO-2t1kXgljqnaU-P1hQGHQBiJMcNCLwELhB"
-            "ZT_vHvkZHFrmgfcTzED_AMdB9mTpvUm_Mk0d3F3RzLtyCeAApOPJaRAwccAc3PB1pKTwjFhdzIXtxib0_MQ6_F1fh"
-            "b8R8ZcLCbwhMtT8nXoeWJOvH9_71O_vkfOn6E-VwLo17jkvQJOa89KfctGNnHNMcPBBju0oIgp_UVal311SMUw_10"
-            "i4GZZkjR2I1m7EMg5jMwQgUatYWv2J5HoefAQQDat9jJeEnYNITxsJMN81FHTyuvMnN_ulFzOGtcvlBpmP6jVHfED"
-            "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"
-        },
-    )
-    assert response.status_code == 401
-    assert response.json == {
-        "message": "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
-    }
-
-
-def test_authentication_failure_invalid_key_identifier_in_token_on_put(
-    client, responses
-):
-    responses.add(
-        responses.GET,
-        "https://test_identity_provider",
-        json={
-            "keys": [
-                {
-                    "kid": "SSQdhI1cKvhQEDSJxE2gGYs40Q1",
-                    "x5c": [
-                        "MIIDBTCCAe2gAwIBAgIQdEMOjSqDVbdN3mzb2IumCzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDYwNDAwMDAwMFoXDTIxMDYwNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKEUUBvom99MdPXlrQ6S9MFmoQPoYI3NJVqEFOJcARY11dj3zyJogL8MTsTRt+DIJ8NyvYbgWC7K7zkAGzHQZhPJcM/AxSjFqh6qB98UqgxoSGBaG0A4lUZJHnKW3qx+YaiWrkg+z4sAwUkP0QgyI29Ejpkk6WUfe1rOJNc/defFUX+AVGxo81beLVAM/8tnCOSbF0H3IADwd76D/Hrp8RsGf4jPHr8N4VDsO/p7oj8rbOx0pL1ehjMK13zspmP8NO5mMcP9i5yiJ37FgbXESAxvja7I9t+y4LQYSu05M7la4Lqv//m5A8MBd6k0VxgF/Sq8GOIbkcQ0bJTCIN9B6oMCAwEAAaMhMB8wHQYDVR0OBBYEFNRP0Lf6MDeL11RDH0uL7H+/JqtLMA0GCSqGSIb3DQEBCwUAA4IBAQCJKR1nxp9Ij/yisCmDG7bdN1yHj/2HdVvyLfCCyReRfkB3cnTZVaIOBy5occGkdmsYJ+q8uqczkoCMAz3gvvq1c0msKEiNpqWNeU2aRXqyL3QZJ/GBmUK1I0tINPVv8j7znm0DcvHHXFvhzS8E4s8ai8vQkcpyac/7Z4PN43HtjDnkZo9Zxm7JahHshrhA8sSPvsuC4dQAcHbOrLbHG+HIo3Tq2pNl7mfQ9fVJ2FxbqlzPYr/rK8H2GTA6N55SuP3KTNvyL3RnMa3hXmGTdG1dpMFzD/IE623h/BqY6j29PyQC/+MUD4UCZ6KW9oIzpi27pKQagH1i1jpBU/ceH6AW"
-                    ],
-                }
-            ]
-        },
-    )
-    response = client.put(
-        "/requires_authentication",
-        headers={
-            "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
-            "IsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiIyYmVmNzMzZC03NWJlLTQxNTktYj"
-            "I4MC02NzJlMDU0OTM4YzMiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8yNDEzOWQxNC1jNjJjLTRjNDc"
-            "tOGJkZC1jZTcxZWExZDUwY2YvIiwiaWF0IjoxNTIwMjcwNTAxLCJuYmYiOjE1MjAyNzA1MDEsImV4cCI6MTUyMDI3"
-            "NDQwMSwiYWlvIjoiWTJOZ1lFaHlXMjYwVS9kR1RGeWNTMWNPVnczYnpqVXQ0Zk96TkNTekJYaWMyWTVOWFFNQSIsI"
-            "mFtciI6WyJwd2QiXSwiZmFtaWx5X25hbWUiOiJCb3Vub3VhciIsImdpdmVuX25hbWUiOiJDb2xpbiIsImlwYWRkci"
-            "I6IjE5NC4yOS45OC4xNDQiLCJuYW1lIjoiQm91bm91YXIgQ29saW4gKEVOR0lFIEVuZXJneSBNYW5hZ2VtZW50KSI"
-            "sIm5vbmNlIjoiW1x1MDAyNzczNjJDQUVBLTlDQTUtNEI0My05QkEzLTM0RDdDMzAzRUJBN1x1MDAyN10iLCJvaWQi"
-            "OiJkZTZiOGVjYS01ZTEzLTRhZTEtODcyMS1mZGNmNmI0YTljZGQiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMTQwO"
-            "TA4MjIzMy0xNDE3MDAxMzMzLTY4MjAwMzMzMC0zNzY5NTQiLCJzdWIiOiI2eEZSV1FBaElOZ0I4Vy10MnJRVUJzcE"
-            "lGc1VyUXQ0UUZ1V1VkSmRxWFdnIiwidGlkIjoiMjQxMzlkMTQtYzYyYy00YzQ3LThiZGQtY2U3MWVhMWQ1MGNmIiw"
-            "idW5pcXVlX25hbWUiOiJKUzUzOTFAZW5naWUuY29tIiwidXBuIjoiSlM1MzkxQGVuZ2llLmNvbSIsInV0aSI6InVm"
-            "M0x0X1Q5aWsyc0hGQ01oNklhQUEiLCJ2ZXIiOiIxLjAifQ.addwLSoO-2t1kXgljqnaU-P1hQGHQBiJMcNCLwELhB"
-            "ZT_vHvkZHFrmgfcTzED_AMdB9mTpvUm_Mk0d3F3RzLtyCeAApOPJaRAwccAc3PB1pKTwjFhdzIXtxib0_MQ6_F1fh"
-            "b8R8ZcLCbwhMtT8nXoeWJOvH9_71O_vkfOn6E-VwLo17jkvQJOa89KfctGNnHNMcPBBju0oIgp_UVal311SMUw_10"
-            "i4GZZkjR2I1m7EMg5jMwQgUatYWv2J5HoefAQQDat9jJeEnYNITxsJMN81FHTyuvMnN_ulFzOGtcvlBpmP6jVHfED"
-            "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"
-        },
-    )
-    assert response.status_code == 401
-    assert response.json == {
-        "message": "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
-    }
-
-
-def test_authentication_failure_invalid_key_identifier_in_token_on_delete(
-    client, responses
-):
-    responses.add(
-        responses.GET,
-        "https://test_identity_provider",
-        json={
-            "keys": [
-                {
-                    "kid": "SSQdhI1cKvhQEDSJxE2gGYs40Q1",
-                    "x5c": [
-                        "MIIDBTCCAe2gAwIBAgIQdEMOjSqDVbdN3mzb2IumCzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDYwNDAwMDAwMFoXDTIxMDYwNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKEUUBvom99MdPXlrQ6S9MFmoQPoYI3NJVqEFOJcARY11dj3zyJogL8MTsTRt+DIJ8NyvYbgWC7K7zkAGzHQZhPJcM/AxSjFqh6qB98UqgxoSGBaG0A4lUZJHnKW3qx+YaiWrkg+z4sAwUkP0QgyI29Ejpkk6WUfe1rOJNc/defFUX+AVGxo81beLVAM/8tnCOSbF0H3IADwd76D/Hrp8RsGf4jPHr8N4VDsO/p7oj8rbOx0pL1ehjMK13zspmP8NO5mMcP9i5yiJ37FgbXESAxvja7I9t+y4LQYSu05M7la4Lqv//m5A8MBd6k0VxgF/Sq8GOIbkcQ0bJTCIN9B6oMCAwEAAaMhMB8wHQYDVR0OBBYEFNRP0Lf6MDeL11RDH0uL7H+/JqtLMA0GCSqGSIb3DQEBCwUAA4IBAQCJKR1nxp9Ij/yisCmDG7bdN1yHj/2HdVvyLfCCyReRfkB3cnTZVaIOBy5occGkdmsYJ+q8uqczkoCMAz3gvvq1c0msKEiNpqWNeU2aRXqyL3QZJ/GBmUK1I0tINPVv8j7znm0DcvHHXFvhzS8E4s8ai8vQkcpyac/7Z4PN43HtjDnkZo9Zxm7JahHshrhA8sSPvsuC4dQAcHbOrLbHG+HIo3Tq2pNl7mfQ9fVJ2FxbqlzPYr/rK8H2GTA6N55SuP3KTNvyL3RnMa3hXmGTdG1dpMFzD/IE623h/BqY6j29PyQC/+MUD4UCZ6KW9oIzpi27pKQagH1i1jpBU/ceH6AW"
-                    ],
-                }
-            ]
-        },
-    )
-    response = client.delete(
-        "/requires_authentication",
-        headers={
-            "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
-            "IsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiIyYmVmNzMzZC03NWJlLTQxNTktYj"
-            "I4MC02NzJlMDU0OTM4YzMiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8yNDEzOWQxNC1jNjJjLTRjNDc"
-            "tOGJkZC1jZTcxZWExZDUwY2YvIiwiaWF0IjoxNTIwMjcwNTAxLCJuYmYiOjE1MjAyNzA1MDEsImV4cCI6MTUyMDI3"
-            "NDQwMSwiYWlvIjoiWTJOZ1lFaHlXMjYwVS9kR1RGeWNTMWNPVnczYnpqVXQ0Zk96TkNTekJYaWMyWTVOWFFNQSIsI"
-            "mFtciI6WyJwd2QiXSwiZmFtaWx5X25hbWUiOiJCb3Vub3VhciIsImdpdmVuX25hbWUiOiJDb2xpbiIsImlwYWRkci"
-            "I6IjE5NC4yOS45OC4xNDQiLCJuYW1lIjoiQm91bm91YXIgQ29saW4gKEVOR0lFIEVuZXJneSBNYW5hZ2VtZW50KSI"
-            "sIm5vbmNlIjoiW1x1MDAyNzczNjJDQUVBLTlDQTUtNEI0My05QkEzLTM0RDdDMzAzRUJBN1x1MDAyN10iLCJvaWQi"
-            "OiJkZTZiOGVjYS01ZTEzLTRhZTEtODcyMS1mZGNmNmI0YTljZGQiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMTQwO"
-            "TA4MjIzMy0xNDE3MDAxMzMzLTY4MjAwMzMzMC0zNzY5NTQiLCJzdWIiOiI2eEZSV1FBaElOZ0I4Vy10MnJRVUJzcE"
-            "lGc1VyUXQ0UUZ1V1VkSmRxWFdnIiwidGlkIjoiMjQxMzlkMTQtYzYyYy00YzQ3LThiZGQtY2U3MWVhMWQ1MGNmIiw"
-            "idW5pcXVlX25hbWUiOiJKUzUzOTFAZW5naWUuY29tIiwidXBuIjoiSlM1MzkxQGVuZ2llLmNvbSIsInV0aSI6InVm"
-            "M0x0X1Q5aWsyc0hGQ01oNklhQUEiLCJ2ZXIiOiIxLjAifQ.addwLSoO-2t1kXgljqnaU-P1hQGHQBiJMcNCLwELhB"
-            "ZT_vHvkZHFrmgfcTzED_AMdB9mTpvUm_Mk0d3F3RzLtyCeAApOPJaRAwccAc3PB1pKTwjFhdzIXtxib0_MQ6_F1fh"
-            "b8R8ZcLCbwhMtT8nXoeWJOvH9_71O_vkfOn6E-VwLo17jkvQJOa89KfctGNnHNMcPBBju0oIgp_UVal311SMUw_10"
-            "i4GZZkjR2I1m7EMg5jMwQgUatYWv2J5HoefAQQDat9jJeEnYNITxsJMN81FHTyuvMnN_ulFzOGtcvlBpmP6jVHfED"
-            "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"
-        },
-    )
-    assert response.status_code == 401
-    assert response.json == {
-        "message": "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
-    }
+    assert response.json == {"message": "Signature verification failed."}
 
 
 def test_user_id_filter_with_value_not_set_in_header(client):
@@ -364,8 +215,15 @@ def test_user_id_filter_with_value_set_in_header(client):
     assert response.get_data(as_text=True) == "JS5391@engie.com"
 
 
-def test_user_id_filter_with_value_already_set_in_flask_globals(client, auth_mock):
-    client.get("/requires_authentication")
+def test_user_id_filter_with_invalid_value_set_in_header(client):
+    response = client.get("/user_id", headers={"Authorization": "Bearer my_token"})
+    assert response.get_data(as_text=True) == ""
+
+
+def test_user_id_filter_with_value_already_set_in_flask_globals(
+    client: flask.testing.FlaskClient, auth_mock
+):
+    client.get("/requires_authentication", headers={"Authorization": "Bearer my_token"})
 
     record = namedtuple("TestRecord", [])
     layabauth.flask.UserIdFilter("upn").filter(record)
@@ -379,11 +237,54 @@ def test_user_id_filter_without_flask():
 
 
 @pytest.fixture
+def identity_provider_url():
+    return "https://test_identity_provider"
+
+
+@pytest.fixture
 def token_body():
     return {"upn": "TEST@email.com"}
 
 
-def test_auth_mock(client, auth_mock):
-    response = client.delete("/requires_authentication")
+@pytest.mark.parametrize("method", ["GET", "POST", "PUT", "DELETE"])
+def test_auth_mock(client: flask.testing.FlaskClient, auth_mock, method: str):
+    response = client.open(
+        method=method,
+        path="/requires_authentication",
+        headers={"Authorization": "Bearer my_token"},
+    )
     assert response.status_code == 200
-    assert response.get_data(as_text=True) == '"OK"\n'
+    assert response.json == {"upn": "TEST@email.com"}
+
+
+def test_keys_cannot_be_retrieved_due_to_network_failure(
+    client: flask.testing.FlaskClient, responses: RequestsMock
+):
+    def raise_exception(*args, **kwargs):
+        raise requests.exceptions.Timeout("description")
+
+    responses.add_callback(
+        responses.GET, "https://test_identity_provider", callback=raise_exception
+    )
+    response = client.get(
+        "/requires_authentication", headers={"Authorization": "Bearer my_token"}
+    )
+    assert response.status_code == 401
+    assert response.json == {
+        "message": "Timeout error while retrieving keys: description"
+    }
+
+
+def test_keys_cannot_be_retrieved_due_to_http_failure(
+    client: flask.testing.FlaskClient, responses: RequestsMock
+):
+    responses.add(
+        responses.GET, "https://test_identity_provider", status=500, body=b"description"
+    )
+    response = client.get(
+        "/requires_authentication", headers={"Authorization": "Bearer my_token"}
+    )
+    assert response.status_code == 401
+    assert response.json == {
+        "message": "HTTP 500 error while retrieving keys: description"
+    }

--- a/tests/test_starlette.py
+++ b/tests/test_starlette.py
@@ -13,7 +13,7 @@ from layabauth.testing import *
 @pytest.fixture
 def client() -> starlette.testclient.TestClient:
     backend = layabauth.starlette.OAuth2IdTokenBackend(
-        identity_provider_url="https://test_identity_provider",
+        jwks_uri="https://test_identity_provider",
         create_user=lambda token, token_body: SimpleUser(token_body["upn"]),
         scopes=lambda token, token_body: ["my_scope"],
     )
@@ -140,7 +140,7 @@ def test_with_invalid_jwt(
 
 
 @pytest.fixture
-def identity_provider_url():
+def jwks_uri():
     return "https://test_identity_provider"
 
 

--- a/tests/test_starlette.py
+++ b/tests/test_starlette.py
@@ -1,3 +1,4 @@
+import requests
 import starlette.applications
 import starlette.testclient
 from starlette.authentication import SimpleUser, requires
@@ -10,7 +11,7 @@ from layabauth.testing import *
 
 
 @pytest.fixture
-def client():
+def client() -> starlette.testclient.TestClient:
     backend = layabauth.starlette.OAuth2IdTokenBackend(
         identity_provider_url="https://test_identity_provider",
         create_user=lambda token, token_body: SimpleUser(token_body["upn"]),
@@ -43,76 +44,32 @@ def client():
     return starlette.testclient.TestClient(application)
 
 
-def test_authentication_failure_token_not_provided_on_get(client):
-    response = client.get("/requires_authentication")
+@pytest.mark.parametrize("method", ["GET", "POST", "PUT", "DELETE"])
+def test_without_authentication_header(
+    client: starlette.testclient.TestClient, method: str
+):
+    response = client.request(method, "/requires_authentication")
     assert response.status_code == 403
     assert response.text == "Forbidden"
 
 
-def test_authentication_failure_token_not_provided_on_post(client):
-    response = client.post("/requires_authentication")
-    assert response.status_code == 403
-    assert response.text == "Forbidden"
-
-
-def test_authentication_failure_token_not_provided_on_put(client):
-    response = client.put("/requires_authentication")
-    assert response.status_code == 403
-    assert response.text == "Forbidden"
-
-
-def test_authentication_failure_token_not_provided_on_delete(client):
-    response = client.delete("/requires_authentication")
-    assert response.status_code == 403
-    assert response.text == "Forbidden"
-
-
-def test_authentication_failure_fake_token_provided_on_get(client):
-    response = client.get(
-        "/requires_authentication", headers={"Authorization": "Bearer Fake token"}
+@pytest.mark.parametrize("method", ["GET", "POST", "PUT", "DELETE"])
+def test_with_non_jwt(
+    client: starlette.testclient.TestClient, responses: RequestsMock, method: str
+):
+    responses.add(method=responses.GET, url="https://test_identity_provider")
+    response = client.request(
+        method,
+        "/requires_authentication",
+        headers={"Authorization": "Bearer Fake token"},
     )
     assert response.status_code == 400
-    assert (
-        response.text
-        == "Invalid JWT Token (header, body and signature must be separated by dots)."
-    )
+    assert response.text == "Not enough segments"
 
 
-def test_authentication_failure_fake_token_provided_on_post(client):
-    response = client.post(
-        "/requires_authentication", headers={"Authorization": "Bearer Fake token"}
-    )
-    assert response.status_code == 400
-    assert (
-        response.text
-        == "Invalid JWT Token (header, body and signature must be separated by dots)."
-    )
-
-
-def test_authentication_failure_fake_token_provided_on_put(client):
-    response = client.put(
-        "/requires_authentication", headers={"Authorization": "Bearer Fake token"}
-    )
-    assert response.status_code == 400
-    assert (
-        response.text
-        == "Invalid JWT Token (header, body and signature must be separated by dots)."
-    )
-
-
-def test_authentication_failure_fake_token_provided_on_delete(client):
-    response = client.delete(
-        "/requires_authentication", headers={"Authorization": "Bearer Fake token"}
-    )
-    assert response.status_code == 400
-    assert (
-        response.text
-        == "Invalid JWT Token (header, body and signature must be separated by dots)."
-    )
-
-
-def test_authentication_failure_invalid_key_identifier_in_token_on_get(
-    client, responses
+@pytest.mark.parametrize("method", ["GET", "POST", "PUT", "DELETE"])
+def test_with_invalid_jwt(
+    client: starlette.testclient.TestClient, responses: RequestsMock, method: str
 ):
     responses.add(
         responses.GET,
@@ -120,15 +77,43 @@ def test_authentication_failure_invalid_key_identifier_in_token_on_get(
         json={
             "keys": [
                 {
-                    "kid": "SSQdhI1cKvhQEDSJxE2gGYs40Q1",
+                    "kty": "RSA",
+                    "use": "sig",
+                    "kid": "CtTuhMJmD5M7DLdzD2v2x3QKSRY",
+                    "x5t": "CtTuhMJmD5M7DLdzD2v2x3QKSRY",
+                    "n": "18uZ3P3IgOySlnOsxeIN5WUKzvlm6evPDMFbmXPtTF0GMe7tD2JPfai2UGn74s7AFwqxWO5DQZRu6VfQUux8uMR4J7nxm1Kf__7pVEVJJyDuL5a8PARRYQtH68w-0IZxcFOkgsSdhtIzPQ2jj4mmRzWXIwh8M_8pJ6qiOjvjF9bhEq0CC_f27BnljPaFn8hxY69pCoxenWWqFcsUhFZvCMthhRubAbBilDr74KaXS5xCgySBhPzwekD9_NdCUuCsdqavd4T-VWnbplbB8YsC-R00FptBFKuTyT9zoGZjWZilQVmj7v3k8jXqYB2nWKgTAfwjmiyKz78FHkaE-nCIDw",
+                    "e": "AQAB",
                     "x5c": [
-                        "MIIDBTCCAe2gAwIBAgIQdEMOjSqDVbdN3mzb2IumCzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDYwNDAwMDAwMFoXDTIxMDYwNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKEUUBvom99MdPXlrQ6S9MFmoQPoYI3NJVqEFOJcARY11dj3zyJogL8MTsTRt+DIJ8NyvYbgWC7K7zkAGzHQZhPJcM/AxSjFqh6qB98UqgxoSGBaG0A4lUZJHnKW3qx+YaiWrkg+z4sAwUkP0QgyI29Ejpkk6WUfe1rOJNc/defFUX+AVGxo81beLVAM/8tnCOSbF0H3IADwd76D/Hrp8RsGf4jPHr8N4VDsO/p7oj8rbOx0pL1ehjMK13zspmP8NO5mMcP9i5yiJ37FgbXESAxvja7I9t+y4LQYSu05M7la4Lqv//m5A8MBd6k0VxgF/Sq8GOIbkcQ0bJTCIN9B6oMCAwEAAaMhMB8wHQYDVR0OBBYEFNRP0Lf6MDeL11RDH0uL7H+/JqtLMA0GCSqGSIb3DQEBCwUAA4IBAQCJKR1nxp9Ij/yisCmDG7bdN1yHj/2HdVvyLfCCyReRfkB3cnTZVaIOBy5occGkdmsYJ+q8uqczkoCMAz3gvvq1c0msKEiNpqWNeU2aRXqyL3QZJ/GBmUK1I0tINPVv8j7znm0DcvHHXFvhzS8E4s8ai8vQkcpyac/7Z4PN43HtjDnkZo9Zxm7JahHshrhA8sSPvsuC4dQAcHbOrLbHG+HIo3Tq2pNl7mfQ9fVJ2FxbqlzPYr/rK8H2GTA6N55SuP3KTNvyL3RnMa3hXmGTdG1dpMFzD/IE623h/BqY6j29PyQC/+MUD4UCZ6KW9oIzpi27pKQagH1i1jpBU/ceH6AW"
+                        "MIIDBTCCAe2gAwIBAgIQXVogj9BAf49IpuOSIvztNDANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTIwMDMxNzAwMDAwMFoXDTI1MDMxNzAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANfLmdz9yIDskpZzrMXiDeVlCs75ZunrzwzBW5lz7UxdBjHu7Q9iT32otlBp++LOwBcKsVjuQ0GUbulX0FLsfLjEeCe58ZtSn//+6VRFSScg7i+WvDwEUWELR+vMPtCGcXBTpILEnYbSMz0No4+Jpkc1lyMIfDP/KSeqojo74xfW4RKtAgv39uwZ5Yz2hZ/IcWOvaQqMXp1lqhXLFIRWbwjLYYUbmwGwYpQ6++Cml0ucQoMkgYT88HpA/fzXQlLgrHamr3eE/lVp26ZWwfGLAvkdNBabQRSrk8k/c6BmY1mYpUFZo+795PI16mAdp1ioEwH8I5osis+/BR5GhPpwiA8CAwEAAaMhMB8wHQYDVR0OBBYEFF8MDGklOGhGNVJvsHHRCaqtzexcMA0GCSqGSIb3DQEBCwUAA4IBAQCKkegw/mdpCVl1lOpgU4G9RT+1gtcPqZK9kpimuDggSJju6KUQlOCi5/lIH5DCzpjFdmG17TjWVBNve5kowmrhLzovY0Ykk7+6hYTBK8dNNSmd4SK7zY++0aDIuOzHP2Cur+kgFC0gez50tPzotLDtMmp40gknXuzltwJfezNSw3gLgljDsGGcDIXK3qLSYh44qSuRGwulcN2EJUZBI9tIxoODpaWHIN8+z2uZvf8JBYFjA3+n9FRQn51X16CTcjq4QRTbNVpgVuQuyaYnEtx0ZnDvguB3RjGSPIXTRBkLl2x7e8/6uAZ6tchw8rhcOtPsFgJuoJokGjvcUSR/6Eqd"
                     ],
-                }
+                },
+                {
+                    "kty": "RSA",
+                    "use": "sig",
+                    "kid": "SsZsBNhZcF3Q9S4trpQBTByNRRI",
+                    "x5t": "SsZsBNhZcF3Q9S4trpQBTByNRRI",
+                    "n": "uHPewhg4WC3eLVPkEFlj7RDtaKYWXCI5G-LPVzsMKOuIu7qQQbeytIA6P6HT9_iIRt8zNQvuw4P9vbNjgUCpI6vfZGsjk3XuCVoB_bAIhvuBcQh9ePH2yEwS5reR-NrG1PsqzobnZZuigKCoDmuOb_UDx1DiVyNCbMBlEG7UzTQwLf5NP6HaRHx027URJeZvPAWY7zjHlSOuKoS_d1yUveaBFIgZqPWLCg44ck4gvik45HsNVWT9zYfT74dvUSSrMSR-SHFT7Hy1XjbVXpHJHNNAXpPoGoWXTuc0BxMsB4cqjfJqoftFGOG4x32vEzakArLPxAKwGvkvu0jToAyvSQ",
+                    "e": "AQAB",
+                    "x5c": [
+                        "MIIDBTCCAe2gAwIBAgIQWHw7h/Ysh6hPcXpnrJ0N8DANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTIwMDQyNzAwMDAwMFoXDTI1MDQyNzAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALhz3sIYOFgt3i1T5BBZY+0Q7WimFlwiORviz1c7DCjriLu6kEG3srSAOj+h0/f4iEbfMzUL7sOD/b2zY4FAqSOr32RrI5N17glaAf2wCIb7gXEIfXjx9shMEua3kfjaxtT7Ks6G52WbooCgqA5rjm/1A8dQ4lcjQmzAZRBu1M00MC3+TT+h2kR8dNu1ESXmbzwFmO84x5UjriqEv3dclL3mgRSIGaj1iwoOOHJOIL4pOOR7DVVk/c2H0++Hb1EkqzEkfkhxU+x8tV421V6RyRzTQF6T6BqFl07nNAcTLAeHKo3yaqH7RRjhuMd9rxM2pAKyz8QCsBr5L7tI06AMr0kCAwEAAaMhMB8wHQYDVR0OBBYEFOI7M+DDFMlP7Ac3aomPnWo1QL1SMA0GCSqGSIb3DQEBCwUAA4IBAQBv+8rBiDY8sZDBoUDYwFQM74QjqCmgNQfv5B0Vjwg20HinERjQeH24uAWzyhWN9++FmeY4zcRXDY5UNmB0nJz7UGlprA9s7voQ0Lkyiud0DO072RPBg38LmmrqoBsLb3MB9MZ2CGBaHftUHfpdTvrgmXSP0IJn7mCUq27g+hFk7n/MLbN1k8JswEODIgdMRvGqN+mnrPKkviWmcVAZccsWfcmS1pKwXqICTKzd6WmVdz+cL7ZSd9I2X0pY4oRwauoE2bS95vrXljCYgLArI3XB2QcnglDDBRYu3Z3aIJb26PTIyhkVKT7xaXhXl4OgrbmQon9/O61G2dzpjzzBPqNP"
+                    ],
+                },
+                {
+                    "kty": "RSA",
+                    "use": "sig",
+                    "kid": "M6pX7RHoraLsprfJeRCjSxuURhc",
+                    "x5t": "M6pX7RHoraLsprfJeRCjSxuURhc",
+                    "n": "xHScZMPo8FifoDcrgncWQ7mGJtiKhrsho0-uFPXg-OdnRKYudTD7-Bq1MDjcqWRf3IfDVjFJixQS61M7wm9wALDj--lLuJJ9jDUAWTA3xWvQLbiBM-gqU0sj4mc2lWm6nPfqlyYeWtQcSC0sYkLlayNgX4noKDaXivhVOp7bwGXq77MRzeL4-9qrRYKjuzHfZL7kNBCsqO185P0NI2Jtmw-EsqYsrCaHsfNRGRrTvUHUq3hWa859kK_5uNd7TeY2ZEwKVD8ezCmSfR59ZzyxTtuPpkCSHS9OtUvS3mqTYit73qcvprjl3R8hpjXLb8oftfpWr3hFRdpxrwuoQEO4QQ",
+                    "e": "AQAB",
+                    "x5c": [
+                        "MIIC8TCCAdmgAwIBAgIQfEWlTVc1uINEc9RBi6qHMjANBgkqhkiG9w0BAQsFADAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwHhcNMTgxMDE0MDAwMDAwWhcNMjAxMDE0MDAwMDAwWjAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDEdJxkw+jwWJ+gNyuCdxZDuYYm2IqGuyGjT64U9eD452dEpi51MPv4GrUwONypZF/ch8NWMUmLFBLrUzvCb3AAsOP76Uu4kn2MNQBZMDfFa9AtuIEz6CpTSyPiZzaVabqc9+qXJh5a1BxILSxiQuVrI2BfiegoNpeK+FU6ntvAZervsxHN4vj72qtFgqO7Md9kvuQ0EKyo7Xzk/Q0jYm2bD4SypiysJoex81EZGtO9QdSreFZrzn2Qr/m413tN5jZkTApUPx7MKZJ9Hn1nPLFO24+mQJIdL061S9LeapNiK3vepy+muOXdHyGmNctvyh+1+laveEVF2nGvC6hAQ7hBAgMBAAGjITAfMB0GA1UdDgQWBBQ5TKadw06O0cvXrQbXW0Nb3M3h/DANBgkqhkiG9w0BAQsFAAOCAQEAI48JaFtwOFcYS/3pfS5+7cINrafXAKTL+/+he4q+RMx4TCu/L1dl9zS5W1BeJNO2GUznfI+b5KndrxdlB6qJIDf6TRHh6EqfA18oJP5NOiKhU4pgkF2UMUw4kjxaZ5fQrSoD9omjfHAFNjradnHA7GOAoF4iotvXDWDBWx9K4XNZHWvD11Td66zTg5IaEQDIZ+f8WS6nn/98nAVMDtR9zW7Te5h9kGJGfe6WiHVaGRPpBvqC4iypGHjbRwANwofZvmp5wP08hY1CsnKY5tfP+E2k/iAQgKKa6QoxXToYvP7rsSkglak8N5g/+FJGnq4wP6cOzgZpjdPMwaVt5432GA=="
+                    ],
+                },
             ]
         },
     )
-    response = client.get(
+    response = client.request(
+        method,
         "/requires_authentication",
         headers={
             "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
@@ -151,148 +136,12 @@ def test_authentication_failure_invalid_key_identifier_in_token_on_get(
         },
     )
     assert response.status_code == 400
-    assert (
-        response.text
-        == "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
-    )
+    assert response.text == "Signature verification failed."
 
 
-def test_authentication_failure_invalid_key_identifier_in_token_on_post(
-    client, responses
-):
-    responses.add(
-        responses.GET,
-        "https://test_identity_provider",
-        json={
-            "keys": [
-                {
-                    "kid": "SSQdhI1cKvhQEDSJxE2gGYs40Q1",
-                    "x5c": [
-                        "MIIDBTCCAe2gAwIBAgIQdEMOjSqDVbdN3mzb2IumCzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDYwNDAwMDAwMFoXDTIxMDYwNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKEUUBvom99MdPXlrQ6S9MFmoQPoYI3NJVqEFOJcARY11dj3zyJogL8MTsTRt+DIJ8NyvYbgWC7K7zkAGzHQZhPJcM/AxSjFqh6qB98UqgxoSGBaG0A4lUZJHnKW3qx+YaiWrkg+z4sAwUkP0QgyI29Ejpkk6WUfe1rOJNc/defFUX+AVGxo81beLVAM/8tnCOSbF0H3IADwd76D/Hrp8RsGf4jPHr8N4VDsO/p7oj8rbOx0pL1ehjMK13zspmP8NO5mMcP9i5yiJ37FgbXESAxvja7I9t+y4LQYSu05M7la4Lqv//m5A8MBd6k0VxgF/Sq8GOIbkcQ0bJTCIN9B6oMCAwEAAaMhMB8wHQYDVR0OBBYEFNRP0Lf6MDeL11RDH0uL7H+/JqtLMA0GCSqGSIb3DQEBCwUAA4IBAQCJKR1nxp9Ij/yisCmDG7bdN1yHj/2HdVvyLfCCyReRfkB3cnTZVaIOBy5occGkdmsYJ+q8uqczkoCMAz3gvvq1c0msKEiNpqWNeU2aRXqyL3QZJ/GBmUK1I0tINPVv8j7znm0DcvHHXFvhzS8E4s8ai8vQkcpyac/7Z4PN43HtjDnkZo9Zxm7JahHshrhA8sSPvsuC4dQAcHbOrLbHG+HIo3Tq2pNl7mfQ9fVJ2FxbqlzPYr/rK8H2GTA6N55SuP3KTNvyL3RnMa3hXmGTdG1dpMFzD/IE623h/BqY6j29PyQC/+MUD4UCZ6KW9oIzpi27pKQagH1i1jpBU/ceH6AW"
-                    ],
-                }
-            ]
-        },
-    )
-    response = client.post(
-        "/requires_authentication",
-        headers={
-            "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
-            "IsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiIyYmVmNzMzZC03NWJlLTQxNTktYj"
-            "I4MC02NzJlMDU0OTM4YzMiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8yNDEzOWQxNC1jNjJjLTRjNDc"
-            "tOGJkZC1jZTcxZWExZDUwY2YvIiwiaWF0IjoxNTIwMjcwNTAxLCJuYmYiOjE1MjAyNzA1MDEsImV4cCI6MTUyMDI3"
-            "NDQwMSwiYWlvIjoiWTJOZ1lFaHlXMjYwVS9kR1RGeWNTMWNPVnczYnpqVXQ0Zk96TkNTekJYaWMyWTVOWFFNQSIsI"
-            "mFtciI6WyJwd2QiXSwiZmFtaWx5X25hbWUiOiJCb3Vub3VhciIsImdpdmVuX25hbWUiOiJDb2xpbiIsImlwYWRkci"
-            "I6IjE5NC4yOS45OC4xNDQiLCJuYW1lIjoiQm91bm91YXIgQ29saW4gKEVOR0lFIEVuZXJneSBNYW5hZ2VtZW50KSI"
-            "sIm5vbmNlIjoiW1x1MDAyNzczNjJDQUVBLTlDQTUtNEI0My05QkEzLTM0RDdDMzAzRUJBN1x1MDAyN10iLCJvaWQi"
-            "OiJkZTZiOGVjYS01ZTEzLTRhZTEtODcyMS1mZGNmNmI0YTljZGQiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMTQwO"
-            "TA4MjIzMy0xNDE3MDAxMzMzLTY4MjAwMzMzMC0zNzY5NTQiLCJzdWIiOiI2eEZSV1FBaElOZ0I4Vy10MnJRVUJzcE"
-            "lGc1VyUXQ0UUZ1V1VkSmRxWFdnIiwidGlkIjoiMjQxMzlkMTQtYzYyYy00YzQ3LThiZGQtY2U3MWVhMWQ1MGNmIiw"
-            "idW5pcXVlX25hbWUiOiJKUzUzOTFAZW5naWUuY29tIiwidXBuIjoiSlM1MzkxQGVuZ2llLmNvbSIsInV0aSI6InVm"
-            "M0x0X1Q5aWsyc0hGQ01oNklhQUEiLCJ2ZXIiOiIxLjAifQ.addwLSoO-2t1kXgljqnaU-P1hQGHQBiJMcNCLwELhB"
-            "ZT_vHvkZHFrmgfcTzED_AMdB9mTpvUm_Mk0d3F3RzLtyCeAApOPJaRAwccAc3PB1pKTwjFhdzIXtxib0_MQ6_F1fh"
-            "b8R8ZcLCbwhMtT8nXoeWJOvH9_71O_vkfOn6E-VwLo17jkvQJOa89KfctGNnHNMcPBBju0oIgp_UVal311SMUw_10"
-            "i4GZZkjR2I1m7EMg5jMwQgUatYWv2J5HoefAQQDat9jJeEnYNITxsJMN81FHTyuvMnN_ulFzOGtcvlBpmP6jVHfED"
-            "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"
-        },
-    )
-    assert response.status_code == 400
-    assert (
-        response.text
-        == "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
-    )
-
-
-def test_authentication_failure_invalid_key_identifier_in_token_on_put(
-    client, responses
-):
-    responses.add(
-        responses.GET,
-        "https://test_identity_provider",
-        json={
-            "keys": [
-                {
-                    "kid": "SSQdhI1cKvhQEDSJxE2gGYs40Q1",
-                    "x5c": [
-                        "MIIDBTCCAe2gAwIBAgIQdEMOjSqDVbdN3mzb2IumCzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDYwNDAwMDAwMFoXDTIxMDYwNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKEUUBvom99MdPXlrQ6S9MFmoQPoYI3NJVqEFOJcARY11dj3zyJogL8MTsTRt+DIJ8NyvYbgWC7K7zkAGzHQZhPJcM/AxSjFqh6qB98UqgxoSGBaG0A4lUZJHnKW3qx+YaiWrkg+z4sAwUkP0QgyI29Ejpkk6WUfe1rOJNc/defFUX+AVGxo81beLVAM/8tnCOSbF0H3IADwd76D/Hrp8RsGf4jPHr8N4VDsO/p7oj8rbOx0pL1ehjMK13zspmP8NO5mMcP9i5yiJ37FgbXESAxvja7I9t+y4LQYSu05M7la4Lqv//m5A8MBd6k0VxgF/Sq8GOIbkcQ0bJTCIN9B6oMCAwEAAaMhMB8wHQYDVR0OBBYEFNRP0Lf6MDeL11RDH0uL7H+/JqtLMA0GCSqGSIb3DQEBCwUAA4IBAQCJKR1nxp9Ij/yisCmDG7bdN1yHj/2HdVvyLfCCyReRfkB3cnTZVaIOBy5occGkdmsYJ+q8uqczkoCMAz3gvvq1c0msKEiNpqWNeU2aRXqyL3QZJ/GBmUK1I0tINPVv8j7znm0DcvHHXFvhzS8E4s8ai8vQkcpyac/7Z4PN43HtjDnkZo9Zxm7JahHshrhA8sSPvsuC4dQAcHbOrLbHG+HIo3Tq2pNl7mfQ9fVJ2FxbqlzPYr/rK8H2GTA6N55SuP3KTNvyL3RnMa3hXmGTdG1dpMFzD/IE623h/BqY6j29PyQC/+MUD4UCZ6KW9oIzpi27pKQagH1i1jpBU/ceH6AW"
-                    ],
-                }
-            ]
-        },
-    )
-    response = client.put(
-        "/requires_authentication",
-        headers={
-            "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
-            "IsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiIyYmVmNzMzZC03NWJlLTQxNTktYj"
-            "I4MC02NzJlMDU0OTM4YzMiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8yNDEzOWQxNC1jNjJjLTRjNDc"
-            "tOGJkZC1jZTcxZWExZDUwY2YvIiwiaWF0IjoxNTIwMjcwNTAxLCJuYmYiOjE1MjAyNzA1MDEsImV4cCI6MTUyMDI3"
-            "NDQwMSwiYWlvIjoiWTJOZ1lFaHlXMjYwVS9kR1RGeWNTMWNPVnczYnpqVXQ0Zk96TkNTekJYaWMyWTVOWFFNQSIsI"
-            "mFtciI6WyJwd2QiXSwiZmFtaWx5X25hbWUiOiJCb3Vub3VhciIsImdpdmVuX25hbWUiOiJDb2xpbiIsImlwYWRkci"
-            "I6IjE5NC4yOS45OC4xNDQiLCJuYW1lIjoiQm91bm91YXIgQ29saW4gKEVOR0lFIEVuZXJneSBNYW5hZ2VtZW50KSI"
-            "sIm5vbmNlIjoiW1x1MDAyNzczNjJDQUVBLTlDQTUtNEI0My05QkEzLTM0RDdDMzAzRUJBN1x1MDAyN10iLCJvaWQi"
-            "OiJkZTZiOGVjYS01ZTEzLTRhZTEtODcyMS1mZGNmNmI0YTljZGQiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMTQwO"
-            "TA4MjIzMy0xNDE3MDAxMzMzLTY4MjAwMzMzMC0zNzY5NTQiLCJzdWIiOiI2eEZSV1FBaElOZ0I4Vy10MnJRVUJzcE"
-            "lGc1VyUXQ0UUZ1V1VkSmRxWFdnIiwidGlkIjoiMjQxMzlkMTQtYzYyYy00YzQ3LThiZGQtY2U3MWVhMWQ1MGNmIiw"
-            "idW5pcXVlX25hbWUiOiJKUzUzOTFAZW5naWUuY29tIiwidXBuIjoiSlM1MzkxQGVuZ2llLmNvbSIsInV0aSI6InVm"
-            "M0x0X1Q5aWsyc0hGQ01oNklhQUEiLCJ2ZXIiOiIxLjAifQ.addwLSoO-2t1kXgljqnaU-P1hQGHQBiJMcNCLwELhB"
-            "ZT_vHvkZHFrmgfcTzED_AMdB9mTpvUm_Mk0d3F3RzLtyCeAApOPJaRAwccAc3PB1pKTwjFhdzIXtxib0_MQ6_F1fh"
-            "b8R8ZcLCbwhMtT8nXoeWJOvH9_71O_vkfOn6E-VwLo17jkvQJOa89KfctGNnHNMcPBBju0oIgp_UVal311SMUw_10"
-            "i4GZZkjR2I1m7EMg5jMwQgUatYWv2J5HoefAQQDat9jJeEnYNITxsJMN81FHTyuvMnN_ulFzOGtcvlBpmP6jVHfED"
-            "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"
-        },
-    )
-    assert response.status_code == 400
-    assert (
-        response.text
-        == "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
-    )
-
-
-def test_authentication_failure_invalid_key_identifier_in_token_on_delete(
-    client, responses
-):
-    responses.add(
-        responses.GET,
-        "https://test_identity_provider",
-        json={
-            "keys": [
-                {
-                    "kid": "SSQdhI1cKvhQEDSJxE2gGYs40Q1",
-                    "x5c": [
-                        "MIIDBTCCAe2gAwIBAgIQdEMOjSqDVbdN3mzb2IumCzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDYwNDAwMDAwMFoXDTIxMDYwNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKEUUBvom99MdPXlrQ6S9MFmoQPoYI3NJVqEFOJcARY11dj3zyJogL8MTsTRt+DIJ8NyvYbgWC7K7zkAGzHQZhPJcM/AxSjFqh6qB98UqgxoSGBaG0A4lUZJHnKW3qx+YaiWrkg+z4sAwUkP0QgyI29Ejpkk6WUfe1rOJNc/defFUX+AVGxo81beLVAM/8tnCOSbF0H3IADwd76D/Hrp8RsGf4jPHr8N4VDsO/p7oj8rbOx0pL1ehjMK13zspmP8NO5mMcP9i5yiJ37FgbXESAxvja7I9t+y4LQYSu05M7la4Lqv//m5A8MBd6k0VxgF/Sq8GOIbkcQ0bJTCIN9B6oMCAwEAAaMhMB8wHQYDVR0OBBYEFNRP0Lf6MDeL11RDH0uL7H+/JqtLMA0GCSqGSIb3DQEBCwUAA4IBAQCJKR1nxp9Ij/yisCmDG7bdN1yHj/2HdVvyLfCCyReRfkB3cnTZVaIOBy5occGkdmsYJ+q8uqczkoCMAz3gvvq1c0msKEiNpqWNeU2aRXqyL3QZJ/GBmUK1I0tINPVv8j7znm0DcvHHXFvhzS8E4s8ai8vQkcpyac/7Z4PN43HtjDnkZo9Zxm7JahHshrhA8sSPvsuC4dQAcHbOrLbHG+HIo3Tq2pNl7mfQ9fVJ2FxbqlzPYr/rK8H2GTA6N55SuP3KTNvyL3RnMa3hXmGTdG1dpMFzD/IE623h/BqY6j29PyQC/+MUD4UCZ6KW9oIzpi27pKQagH1i1jpBU/ceH6AW"
-                    ],
-                }
-            ]
-        },
-    )
-    response = client.delete(
-        "/requires_authentication",
-        headers={
-            "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMC"
-            "IsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiIyYmVmNzMzZC03NWJlLTQxNTktYj"
-            "I4MC02NzJlMDU0OTM4YzMiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8yNDEzOWQxNC1jNjJjLTRjNDc"
-            "tOGJkZC1jZTcxZWExZDUwY2YvIiwiaWF0IjoxNTIwMjcwNTAxLCJuYmYiOjE1MjAyNzA1MDEsImV4cCI6MTUyMDI3"
-            "NDQwMSwiYWlvIjoiWTJOZ1lFaHlXMjYwVS9kR1RGeWNTMWNPVnczYnpqVXQ0Zk96TkNTekJYaWMyWTVOWFFNQSIsI"
-            "mFtciI6WyJwd2QiXSwiZmFtaWx5X25hbWUiOiJCb3Vub3VhciIsImdpdmVuX25hbWUiOiJDb2xpbiIsImlwYWRkci"
-            "I6IjE5NC4yOS45OC4xNDQiLCJuYW1lIjoiQm91bm91YXIgQ29saW4gKEVOR0lFIEVuZXJneSBNYW5hZ2VtZW50KSI"
-            "sIm5vbmNlIjoiW1x1MDAyNzczNjJDQUVBLTlDQTUtNEI0My05QkEzLTM0RDdDMzAzRUJBN1x1MDAyN10iLCJvaWQi"
-            "OiJkZTZiOGVjYS01ZTEzLTRhZTEtODcyMS1mZGNmNmI0YTljZGQiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMTQwO"
-            "TA4MjIzMy0xNDE3MDAxMzMzLTY4MjAwMzMzMC0zNzY5NTQiLCJzdWIiOiI2eEZSV1FBaElOZ0I4Vy10MnJRVUJzcE"
-            "lGc1VyUXQ0UUZ1V1VkSmRxWFdnIiwidGlkIjoiMjQxMzlkMTQtYzYyYy00YzQ3LThiZGQtY2U3MWVhMWQ1MGNmIiw"
-            "idW5pcXVlX25hbWUiOiJKUzUzOTFAZW5naWUuY29tIiwidXBuIjoiSlM1MzkxQGVuZ2llLmNvbSIsInV0aSI6InVm"
-            "M0x0X1Q5aWsyc0hGQ01oNklhQUEiLCJ2ZXIiOiIxLjAifQ.addwLSoO-2t1kXgljqnaU-P1hQGHQBiJMcNCLwELhB"
-            "ZT_vHvkZHFrmgfcTzED_AMdB9mTpvUm_Mk0d3F3RzLtyCeAApOPJaRAwccAc3PB1pKTwjFhdzIXtxib0_MQ6_F1fh"
-            "b8R8ZcLCbwhMtT8nXoeWJOvH9_71O_vkfOn6E-VwLo17jkvQJOa89KfctGNnHNMcPBBju0oIgp_UVal311SMUw_10"
-            "i4GZZkjR2I1m7EMg5jMwQgUatYWv2J5HoefAQQDat9jJeEnYNITxsJMN81FHTyuvMnN_ulFzOGtcvlBpmP6jVHfED"
-            "oJiqFM4NFh6r4IlOs2U2-jUb_bR5xi2zg"
-        },
-    )
-    assert response.status_code == 400
-    assert (
-        response.text
-        == "SSQdhI1cKvhQEDSJxE2gGYs40Q0 is not a valid key identifier. Valid ones are ['SSQdhI1cKvhQEDSJxE2gGYs40Q1']."
-    )
+@pytest.fixture
+def identity_provider_url():
+    return "https://test_identity_provider"
 
 
 @pytest.fixture
@@ -300,9 +149,39 @@ def token_body():
     return {"upn": "TEST@email.com"}
 
 
-def test_auth_mock(client, auth_mock):
-    response = client.delete(
-        "/requires_authentication", headers={"Authorization": "Bearer my_token"}
+@pytest.mark.parametrize("method", ["GET", "POST", "PUT", "DELETE"])
+def test_auth_mock(client: starlette.testclient.TestClient, auth_mock, method: str):
+    response = client.request(
+        method, "/requires_authentication", headers={"Authorization": "Bearer my_token"}
     )
     assert response.status_code == 200
     assert response.text == "TEST@email.com"
+
+
+def test_keys_cannot_be_retrieved_due_to_network_failure(
+    client: starlette.testclient.TestClient, responses: RequestsMock
+):
+    def raise_exception(*args, **kwargs):
+        raise requests.exceptions.Timeout("description")
+
+    responses.add_callback(
+        responses.GET, "https://test_identity_provider", callback=raise_exception
+    )
+    response = client.get(
+        "/requires_authentication", headers={"Authorization": "Bearer my_token"}
+    )
+    assert response.status_code == 400
+    assert response.text == "Timeout error while retrieving keys: description"
+
+
+def test_keys_cannot_be_retrieved_due_to_http_failure(
+    client: starlette.testclient.TestClient, responses: RequestsMock
+):
+    responses.add(
+        responses.GET, "https://test_identity_provider", status=500, body=b"description"
+    )
+    response = client.get(
+        "/requires_authentication", headers={"Authorization": "Bearer my_token"}
+    )
+    assert response.status_code == 400
+    assert response.text == "HTTP 500 error while retrieving keys: description"


### PR DESCRIPTION
### Fixed
- Drop oauth2helper in favor of python-jose to handle all kind of tokens.

### Changed
- `identity_provider_url` has been renamed to `jwks_uri` to match the key in .well-known
- `jwks_uri` pytest fixture needs to be provided in addition to `token_body`.
- Flask tests will require a fake token to be provided in headers (unless you want to test behavior without providing a token).
