### PR TITLE
Release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2020-05-29
+### Changed
+- layabauth.authorizations now requires scopes to be provided as a dictionary inside scopes parameter instead of kwargs.
+
+### Fixed
+- Allow to provide scopes that cannot be stored as python variables (such as names containing `.` (dots) or `-` (minus) symbols).
+
+### Added
+- `layabauth.flask.requires_scopes` function to ensure that expected scopes are received.
+
 ## [4.0.1] - 2020-04-28
 ### Fixed
 - Drop oauth2helper in favor of python-jose to handle all kind of tokens.
@@ -27,7 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/layabauth/compare/v4.0.1...HEAD
+[Unreleased]: https://github.com/Colin-b/layabauth/compare/v5.0.0...HEAD
+[5.0.0]: https://github.com/Colin-b/layabauth/compare/v4.0.1...v5.0.0
 [4.0.1]: https://github.com/Colin-b/layabauth/compare/v4.0.0...v4.0.1
 [4.0.0]: https://github.com/Colin-b/layabauth/compare/v3.2.0...v4.0.0
 [3.2.0]: https://github.com/Colin-b/layabauth/releases/tag/v3.2.0

--- a/layabauth/_openapi.py
+++ b/layabauth/_openapi.py
@@ -1,4 +1,7 @@
-def authorizations(auth_url, **scopes) -> dict:
+from typing import Dict
+
+
+def authorizations(auth_url: str, scopes: Dict[str, str]) -> dict:
     """
     Return all security definitions.
     Contains only one OAuth2 implicit flow definition.
@@ -16,7 +19,7 @@ def authorizations(auth_url, **scopes) -> dict:
     }
 
 
-def method_authorizations(*scopes) -> dict:
+def method_authorizations(*scopes: str) -> dict:
     """
     Return method security.
     Contains only one OAuth2 security.

--- a/layabauth/flask.py
+++ b/layabauth/flask.py
@@ -37,6 +37,26 @@ def requires_authentication(jwks_uri: str):
     return decorator
 
 
+def requires_scopes(scopes: callable, *expected_scopes: str):
+    """
+    Ensure that the token contains the required scopes.
+    Raises werkzeug.exceptions.Forbidden otherwise.
+
+    :param scopes: callable receiving the token and the decoded token body and returning the list of associated scopes str.
+    :param expected_scopes: all expected scopes in the token.
+    """
+    try:
+        scopes = scopes(token=flask.g.token, token_body=flask.g.token_body) or []
+    except:
+        scopes = []
+
+    for expected_scope in expected_scopes:
+        if expected_scope not in scopes:
+            raise werkzeug.exceptions.Forbidden(
+                description=f"The {expected_scope} must be provided in the token."
+            )
+
+
 def _extract_token_body() -> dict:
     if getattr(flask.g, "token_body", None):
         return flask.g.token_body

--- a/layabauth/version.py
+++ b/layabauth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "4.0.1"
+__version__ = "5.0.0"

--- a/tests/test_flask_without_expected_scopes.py
+++ b/tests/test_flask_without_expected_scopes.py
@@ -1,0 +1,46 @@
+import flask
+import flask_restx
+import flask.testing
+
+import layabauth.flask
+from layabauth.testing import *
+
+
+@pytest.fixture
+def app() -> flask.Flask:
+    application = flask.Flask(__name__)
+    application.testing = True
+    api = flask_restx.Api(application)
+
+    @api.route("/requires_scopes")
+    class RequiresScopes(flask_restx.Resource):
+        @layabauth.flask.requires_authentication("https://test_identity_provider")
+        def get(self):
+            layabauth.flask.requires_scopes(
+                lambda token, token_body: token_body["scopes"], "scope1", "scope2"
+            )
+            return flask.g.token_body
+
+    return application
+
+
+@pytest.fixture
+def jwks_uri():
+    return "https://test_identity_provider"
+
+
+@pytest.fixture
+def token_body():
+    return {"upn": "TEST@email.com", "scopes": ["scope2", "scope3"]}
+
+
+def test_auth_mock_with_1_scope_ok_1_missing(
+    client: flask.testing.FlaskClient, auth_mock
+):
+    response = client.open(
+        method="GET",
+        path="/requires_scopes",
+        headers={"Authorization": "Bearer my_token"},
+    )
+    assert response.status_code == 403
+    assert response.json == {"message": "The scope1 must be provided in the token."}

--- a/tests/test_flask_without_scopes.py
+++ b/tests/test_flask_without_scopes.py
@@ -1,0 +1,44 @@
+import flask
+import flask_restx
+import flask.testing
+
+import layabauth.flask
+from layabauth.testing import *
+
+
+@pytest.fixture
+def app() -> flask.Flask:
+    application = flask.Flask(__name__)
+    application.testing = True
+    api = flask_restx.Api(application)
+
+    @api.route("/requires_scopes")
+    class RequiresScopes(flask_restx.Resource):
+        @layabauth.flask.requires_authentication("https://test_identity_provider")
+        def get(self):
+            layabauth.flask.requires_scopes(
+                lambda token, token_body: token_body["scopes"], "scope1", "scope2"
+            )
+            return flask.g.token_body
+
+    return application
+
+
+@pytest.fixture
+def jwks_uri():
+    return "https://test_identity_provider"
+
+
+@pytest.fixture
+def token_body():
+    return {"upn": "TEST@email.com"}
+
+
+def test_auth_mock_without_scopes(client: flask.testing.FlaskClient, auth_mock):
+    response = client.open(
+        method="GET",
+        path="/requires_scopes",
+        headers={"Authorization": "Bearer my_token"},
+    )
+    assert response.status_code == 403
+    assert response.json == {"message": "The scope1 must be provided in the token."}

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -2,17 +2,17 @@ import layabauth
 
 
 def test_method_authorizations():
-    assert layabauth.method_authorizations("test1", "test2") == {
-        "security": [{"oauth2": ("test1", "test2")}]
+    assert layabauth.method_authorizations("t,e-st.1", "test2") == {
+        "security": [{"oauth2": ("t,e-st.1", "test2")}]
     }
 
 
 def test_authorizations():
     assert layabauth.authorizations(
-        "https://test_auth", test1="test1 desc", test2="test2 desc"
+        "https://test_auth", scopes={"t,e-st.1": "test1 desc", "test2": "test2 desc"}
     ) == {
         "oauth2": {
-            "scopes": {"test1": "test1 desc", "test2": "test2 desc"},
+            "scopes": {"t,e-st.1": "test1 desc", "test2": "test2 desc"},
             "flow": "implicit",
             "authorizationUrl": "https://test_auth",
             "type": "oauth2",


### PR DESCRIPTION
### Changed
- layabauth.authorizations now requires scopes to be provided as a dictionary inside scopes parameter instead of kwargs.

### Fixed
- Allow to provide scopes that cannot be stored as python variables (such as names containing `.` (dots) or `-` (minus) symbols).

### Added
- `layabauth.flask.requires_scopes` function to ensure that expected scopes are received.
