### PR TITLE
Release 5.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: master
+    rev: 20.8b1
     hooks:
       - id: black

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - pip install .[testing]
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.1] - 2020-11-17
+### Added
+- Add explicit support for python `3.9`.
+
+### Changed
+- Update [`black`](https://github.com/psf/black/blob/master/CHANGES.md) version from `master` to `20.8b1`.
+- Use `httpx` instead of `requests` to query keys.
+- Testing mock does not rely on `pytest-responses` anymore.
+
+### Fixed
+- Verify SSL certificate by default.
+
 ## [5.0.0] - 2020-05-29
 ### Changed
 - layabauth.authorizations now requires scopes to be provided as a dictionary inside scopes parameter instead of kwargs.
@@ -37,7 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/layabauth/compare/v5.0.0...HEAD
+[Unreleased]: https://github.com/Colin-b/layabauth/compare/v5.0.1...HEAD
+[5.0.1]: https://github.com/Colin-b/layabauth/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/Colin-b/layabauth/compare/v4.0.1...v5.0.0
 [4.0.1]: https://github.com/Colin-b/layabauth/compare/v4.0.0...v4.0.1
 [4.0.0]: https://github.com/Colin-b/layabauth/compare/v3.2.0...v4.0.0

--- a/layabauth/_http.py
+++ b/layabauth/_http.py
@@ -1,6 +1,6 @@
 from typing import Mapping
 
-import requests
+import httpx
 from jose import jwt, exceptions
 
 
@@ -17,15 +17,15 @@ def validate(token: str, key: str) -> dict:
 
 
 # TODO Cache keys for faster token validation
-def keys(jwks_uri: str) -> str:
+def keys(client: httpx.Client, jwks_uri: str) -> str:
     try:
-        response = requests.get(jwks_uri, verify=False)
-    except requests.RequestException as e:
+        response = client.get(jwks_uri)
+    except httpx.HTTPError as e:
         raise exceptions.JOSEError(
             f"{type(e).__name__} error while retrieving keys: {str(e)}"
         )
 
-    if not response:
+    if response.is_error:
         raise exceptions.JOSEError(
             f"HTTP {response.status_code} error while retrieving keys: {response.text}"
         )

--- a/layabauth/starlette.py
+++ b/layabauth/starlette.py
@@ -1,5 +1,6 @@
 from typing import Optional, Tuple
 
+import httpx
 from starlette.authentication import (
     AuthenticationBackend,
     AuthCredentials,
@@ -9,7 +10,7 @@ from starlette.authentication import (
 from starlette.requests import Request
 from jose import exceptions
 
-from layabauth._http import _get_token, validate, keys
+from layabauth import _http
 
 
 class OAuth2IdTokenBackend(AuthenticationBackend):
@@ -17,7 +18,9 @@ class OAuth2IdTokenBackend(AuthenticationBackend):
     Handle authentication via OAuth2 id-token (implicit flow, authorization code, with or without PKCE)
     """
 
-    def __init__(self, jwks_uri: str, create_user: callable, scopes: callable):
+    def __init__(
+        self, jwks_uri: str, create_user: callable, scopes: callable, **httpx_kwargs
+    ):
         """
         :param jwks_uri: The JWKs URI as defined in .well-known.
         For more information on JWK, refer to https://tools.ietf.org/html/rfc7517
@@ -25,21 +28,24 @@ class OAuth2IdTokenBackend(AuthenticationBackend):
             * Microsoft Identity Platform: https://sts.windows.net/common/discovery/keys
         :param create_user: callable receiving the token and the decoded token body and returning a starlette.BaseUser instance.
         :param scopes: callable receiving the token and the decoded token body and returning the list of associated scopes str.
+        :param httpx_kwargs: Any other argument will be provided to httpx.Client to be able to retrieve the keys.
         """
         self.jwks_uri = jwks_uri
         self.create_user = create_user
         self.scopes = scopes
+        self.httpx_kwargs = httpx_kwargs
 
     async def authenticate(
         self, request: Request
     ) -> Optional[Tuple["AuthCredentials", "BaseUser"]]:
-        token = _get_token(request.headers)
+        token = _http._get_token(request.headers)
         if not token:
             return  # Consider that user is not authenticated
 
         try:
-            key = keys(self.jwks_uri)
-            json_body = validate(token, key)
+            with httpx.Client(**self.httpx_kwargs) as client:
+                key = _http.keys(client, self.jwks_uri)
+            json_body = _http.validate(token, key)
         except exceptions.JOSEError as e:
             raise AuthenticationError(str(e)) from e
 

--- a/layabauth/testing.py
+++ b/layabauth/testing.py
@@ -1,12 +1,17 @@
 import pytest
 import layabauth._http
-from responses import RequestsMock
 
 
 @pytest.fixture
-def auth_mock(monkeypatch, responses: RequestsMock, token_body: dict, jwks_uri: str):
+def auth_mock(monkeypatch, token_body: dict, jwks_uri: str):
     # Mock keys
-    responses.add(method=responses.GET, url=jwks_uri)
+    def keys_mock(client, uri):
+        assert (
+            uri == jwks_uri
+        ), f"The mocked JWKS URI does not match the one used by project: {jwks_uri} != {uri}"
+
+    monkeypatch.setattr(layabauth._http, "keys", keys_mock)
+
     # Mock token validation (TODO only deactivate validation so that clients can use raw tokens)
     monkeypatch.setattr(
         layabauth._http.jwt, "decode", lambda *args, **kwargs: token_body

--- a/layabauth/version.py
+++ b/layabauth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "5.0.0"
+__version__ = "5.0.1"

--- a/setup.py
+++ b/setup.py
@@ -30,13 +30,14 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Build Tools",
     ],
     keywords=["flask", "starlette", "auth"],
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         # Used to request JWKs (keys)
-        "requests==2.*",
+        "httpx==0.16.*",
         # Used to manage authentication
         "python-jose==3.*",
     ],
@@ -49,7 +50,7 @@ setup(
             "starlette==0.13.*",
             "requests==2.*",
             # Used to mock requests sent to check keys
-            "pytest-responses==0.4.*",
+            "pytest-httpx==0.10.*",
             # Used to check coverage
             "pytest-cov==2.*",
         ]


### PR DESCRIPTION
### Added
- Add explicit support for python `3.9`.

### Changed
- Update [`black`](https://github.com/psf/black/blob/master/CHANGES.md) version from `master` to `20.8b1`.
- Use `httpx` instead of `requests` to query keys.
- Testing mock does not rely on `pytest-responses` anymore.

### Fixed
- Verify SSL certificate by default.
