### PR TITLE
Release 7.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update [`flask-restx`](https://github.com/python-restx/flask-restx) version from `0.5.*` to `1.1.*`.
+- Update [`httpx`](https://github.com/encode/httpx/blob/master/CHANGELOG.md) version from `0.21.*` to `>=0.21.*, <0.25.`.
+- Update [`pytest-httpx`](https://github.com/Colin-b/pytest_httpx/blob/master/CHANGELOG.md) version from `0.15.*` to `>=0.15.*, <0.23.*`.
 
 ## [6.0.0] - 2021-12-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Drop support for python `3.6`
+- Add support for python `3.11`
 - Update [`flask-restx`](https://github.com/python-restx/flask-restx) version from `0.5.*` to `1.1.*`.
 - Update [`httpx`](https://github.com/encode/httpx/blob/master/CHANGELOG.md) version from `0.21.*` to `>=0.21.*, <0.25.`.
 - Update [`pytest-httpx`](https://github.com/Colin-b/pytest_httpx/blob/master/CHANGELOG.md) version from `0.15.*` to `>=0.15.*, <0.23.*`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Drop support for python `3.6`
 - Add support for python `3.11`
-- Update [`flask-restx`](https://github.com/python-restx/flask-restx) version from `0.5.*` to `1.1.*`.
-- Update [`httpx`](https://github.com/encode/httpx/blob/master/CHANGELOG.md) version from `0.21.*` to `>=0.21.*, <0.25.`.
-- Update [`pytest-httpx`](https://github.com/Colin-b/pytest_httpx/blob/master/CHANGELOG.md) version from `0.15.*` to `>=0.15.*, <0.23.*`.
+- Update [`flask-restx`](https://github.com/python-restx/flask-restx/blob/master/CHANGELOG.rst) version from `0.5.*` to `1.1.*`.
+- Update [`httpx`](https://github.com/encode/httpx/blob/master/CHANGELOG.md) version from `0.21.*` to `0.24.*`.
+- Update [`pytest-httpx`](https://github.com/Colin-b/pytest_httpx/blob/master/CHANGELOG.md) version from `0.15.*` to `0.22.*`.
 
 ## [6.0.0] - 2021-12-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [7.0.0] - 2023-04-26
 ### Changed
 - Drop support for python `3.6`
 - Add support for python `3.11`
@@ -65,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/layabauth/compare/v6.0.0...HEAD
+[Unreleased]: https://github.com/Colin-b/layabauth/compare/v7.0.0...HEAD
+[7.0.0]: https://github.com/Colin-b/layabauth/compare/v6.0.0...v7.0.0
 [6.0.0]: https://github.com/Colin-b/layabauth/compare/v5.1.0...v6.0.0
 [5.1.0]: https://github.com/Colin-b/layabauth/compare/v5.0.1...v5.1.0
 [5.0.1]: https://github.com/Colin-b/layabauth/compare/v5.0.0...v5.0.1

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ def test_authentication(auth_mock, client):
 ```
 
 ## How to install
-1. [python 3.6+](https://www.python.org/downloads/) must be installed
+1. [python 3.7+](https://www.python.org/downloads/) must be installed
 2. Use pip to install module:
 ```sh
 python -m pip install layabauth

--- a/layabauth/version.py
+++ b/layabauth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "6.0.0"
+__version__ = "7.0.0"

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         # Used to request JWKs (keys)
-        "httpx>=0.21.*, <0.25.*",
+        "httpx>=0.21.3, <0.25.0",
         # Used to manage authentication
         "python-jose==3.*",
     ],
@@ -51,7 +51,7 @@ setup(
             "starlette==0.17.*",
             "requests==2.*",
             # Used to mock requests sent to check keys
-            "pytest-httpx>=0.15.*, <0.23.*",
+            "pytest-httpx>=0.15.0, <0.23.0",
             # Used to check coverage
             "pytest-cov==3.*",
         ]

--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,11 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Build Tools",
     ],
     keywords=["flask", "starlette", "auth"],
@@ -56,7 +56,7 @@ setup(
             "pytest-cov==3.*",
         ]
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     project_urls={
         "GitHub": "https://github.com/Colin-b/layabauth",
         "Changelog": "https://github.com/Colin-b/layabauth/blob/master/CHANGELOG.md",

--- a/setup.py
+++ b/setup.py
@@ -38,20 +38,20 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         # Used to request JWKs (keys)
-        "httpx==0.21.*",
+        "httpx>=0.21.*, <0.25.*",
         # Used to manage authentication
         "python-jose==3.*",
     ],
     extras_require={
         "testing": [
             # Used to test flask application
-            "flask_restx==0.5.*",
+            "flask_restx==1.1.*",
             "pytest-flask==1.*",
             # Used to test starlette authentication
             "starlette==0.17.*",
             "requests==2.*",
             # Used to mock requests sent to check keys
-            "pytest-httpx==0.15.*",
+            "pytest-httpx>=0.15.*, <0.23.*",
             # Used to check coverage
             "pytest-cov==3.*",
         ]

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         # Used to request JWKs (keys)
-        "httpx>=0.21.3, <0.25.0",
+        "httpx==0.24.*",
         # Used to manage authentication
         "python-jose==3.*",
     ],
@@ -51,7 +51,7 @@ setup(
             "starlette==0.17.*",
             "requests==2.*",
             # Used to mock requests sent to check keys
-            "pytest-httpx>=0.15.0, <0.23.0",
+            "pytest-httpx==0.22.*",
             # Used to check coverage
             "pytest-cov==3.*",
         ]


### PR DESCRIPTION
### Changed
- Drop support for python `3.6`
- Add support for python `3.11`
- Update [`flask-restx`](https://github.com/python-restx/flask-restx/blob/master/CHANGELOG.rst) version from `0.5.*` to `1.1.*`.
- Update [`httpx`](https://github.com/encode/httpx/blob/master/CHANGELOG.md) version from `0.21.*` to `0.24.*`.
- Update [`pytest-httpx`](https://github.com/Colin-b/pytest_httpx/blob/master/CHANGELOG.md) version from `0.15.*` to `0.22.*`.
